### PR TITLE
[FEAT] : 회원가입 구현 및 Security 설정 진행

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -19,7 +19,13 @@
 Z9_DB_URL = "jdbc:mysql://localhost:3306/test?serverTimezone=Asia/Seoul"
 Z9_DB_USERNAME = "root"
 Z9_DB_PASSWORD = "1234"
+JWT_SECRET = 'sdlkfnxcoisdfiojvclkmnflkni219o3uj908uxfjn1298i03ujiodusfj10928ijjsklfnwe0ijf1io2j3oi1kklasdf'
+JWT_ACCESS_EXPIRATION = 300000
+JWT_REFRESH_EXPIRATION = 30000000
 ```
+- 이때, `JWT_SECRET` 값은, 최소 32바이트 이상 설정되어야 합니다. 즉, 최소 32개 문자 이상 들어가야 합니다!
+- `JWT_ACCESS_EXPIRATION`, `JWT_REFRESH_EXPIRATION` 은, 각각의 token 의 유효 시간을 나타냅니다. 단위는 ms 입니다.
+  - 즉, 3000 = 3초 
 
 ### 3. 프로젝트 사전 구성
 - 기본적으로, MySQL 8.0v 이상이 설치되어 있어야 합니다.

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,6 +46,15 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/z9/second/domain/authentication/controller/AuthenticationController.java
+++ b/backend/src/main/java/z9/second/domain/authentication/controller/AuthenticationController.java
@@ -1,0 +1,58 @@
+package z9.second.domain.authentication.controller;
+
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
+import static z9.second.global.security.constant.JWTConstant.REFRESH_TOKEN_HEADER;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import z9.second.domain.authentication.dto.AuthenticationRequest;
+import z9.second.domain.authentication.dto.AuthenticationResponse;
+import z9.second.domain.authentication.service.AuthenticationService;
+import z9.second.global.response.BaseResponse;
+import z9.second.global.response.SuccessCode;
+import z9.second.global.security.jwt.JwtProperties;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/")
+@Tag(name = "Authentication Controller", description = "회원 인증 컨트롤러")
+public class AuthenticationController {
+
+    private final AuthenticationService authenticationService;
+    private final JwtProperties jwtProperties;
+
+    @PostMapping("/login")
+    @Operation(summary = "회원 로그인")
+    public BaseResponse<Void> login(
+            @Valid @RequestBody AuthenticationRequest.Login dto,
+            HttpServletResponse response
+    ) {
+        AuthenticationResponse.UserToken token = authenticationService.login(dto);
+        addTokenToResponse(token, response);
+        return BaseResponse.ok(SuccessCode.LOGIN_SUCCESS);
+    }
+
+    private void addTokenToResponse(
+            AuthenticationResponse.UserToken token, HttpServletResponse response) {
+        response.setHeader(ACCESS_TOKEN_HEADER, token.getAccessToken());
+
+        Cookie cookie = new Cookie(REFRESH_TOKEN_HEADER, token.getRefreshToken());
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(parseMsToSec(jwtProperties.getRefreshExpiration()));
+        response.addCookie(cookie);
+    }
+
+    private int parseMsToSec(Long ms) {
+        return (int) (ms / 1000);
+    }
+}

--- a/backend/src/main/java/z9/second/domain/authentication/dto/AuthenticationRequest.java
+++ b/backend/src/main/java/z9/second/domain/authentication/dto/AuthenticationRequest.java
@@ -1,0 +1,28 @@
+package z9.second.domain.authentication.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import z9.second.global.annotation.validation.user.UserLoginId;
+import z9.second.global.annotation.validation.user.UserPassword;
+
+public class AuthenticationRequest {
+
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Login {
+        @UserLoginId
+        private String loginId;
+
+        @UserPassword
+        private String password;
+
+        public static Login of(String loginId, String password) {
+            return new Login(loginId, password);
+        }
+    }
+}

--- a/backend/src/main/java/z9/second/domain/authentication/dto/AuthenticationResponse.java
+++ b/backend/src/main/java/z9/second/domain/authentication/dto/AuthenticationResponse.java
@@ -1,0 +1,27 @@
+package z9.second.domain.authentication.dto;
+
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class AuthenticationResponse {
+
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class UserToken {
+        private String accessToken;
+        private String refreshToken;
+
+        public static UserToken of(String accessToken, String refreshToken) {
+            return UserToken
+                    .builder()
+                    .accessToken(String.format("%s %s", ACCESS_TOKEN_PREFIX, accessToken))
+                    .refreshToken(refreshToken)
+                    .build();
+        }
+    }
+}

--- a/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationService.java
+++ b/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationService.java
@@ -1,0 +1,9 @@
+package z9.second.domain.authentication.service;
+
+import z9.second.domain.authentication.dto.AuthenticationRequest;
+import z9.second.domain.authentication.dto.AuthenticationResponse;
+
+public interface AuthenticationService {
+
+    AuthenticationResponse.UserToken login(AuthenticationRequest.Login dto);
+}

--- a/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationServiceImpl.java
+++ b/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationServiceImpl.java
@@ -1,0 +1,49 @@
+package z9.second.domain.authentication.service;
+
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_CATEGORY;
+import static z9.second.global.security.constant.JWTConstant.REFRESH_TOKEN_CATEGORY;
+
+import java.util.Collection;
+import java.util.Iterator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+import z9.second.domain.authentication.dto.AuthenticationRequest;
+import z9.second.domain.authentication.dto.AuthenticationResponse;
+import z9.second.global.security.jwt.JWTUtil;
+import z9.second.global.security.jwt.JwtProperties;
+import z9.second.global.security.user.CustomUserDetails;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationServiceImpl implements AuthenticationService {
+
+    private final AuthenticationManager authenticationManager;
+    private final JWTUtil jwtUtil;
+    private final JwtProperties jwtProperties;
+
+    @Override
+    public AuthenticationResponse.UserToken login(AuthenticationRequest.Login dto) {
+        UsernamePasswordAuthenticationToken authToken =
+                new UsernamePasswordAuthenticationToken(
+                        dto.getLoginId(), dto.getPassword());
+
+        Authentication authentication = authenticationManager.authenticate(authToken);
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+
+        String role = auth.getAuthority();
+        String userId = userDetails.getUsername();
+
+        String access = jwtUtil.createJwt(ACCESS_TOKEN_CATEGORY, userId, role, jwtProperties.getAccessExpiration());
+        String refresh = jwtUtil.createJwt(REFRESH_TOKEN_CATEGORY, userId, role, jwtProperties.getRefreshExpiration());
+
+        return AuthenticationResponse.UserToken.of(access, refresh);
+    }
+}

--- a/backend/src/main/java/z9/second/domain/sample/controller/SampleController.java
+++ b/backend/src/main/java/z9/second/domain/sample/controller/SampleController.java
@@ -1,7 +1,9 @@
 package z9.second.domain.sample.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -98,5 +100,41 @@ public class SampleController {
         SampleResponse.SavedSampleData savedSampleData
                 = sampleService.saveNewSampleData(newSampleData);
         return BaseResponse.ok(SuccessCode.SAVE_SAMPLE_DATA_SUCCESS, savedSampleData);
+    }
+
+    /**
+     * 회원만 접근 가능한, end Point
+     * 회원만 접근 가능하게 막은 역할은, `SecurityConfig`에, `.requestMatchers()` 로 설정된 부분이 영향을 줍니다.
+     * 또한, 내부적으로는, accessToken 을 활용하여 SecurityContext 에 인증된 회원의 정보를 넣도록 되어있습니다.
+     *      `AuthenticationFilter` 참조!
+     * 결과적으로, Controller 에서, `Principal` 을 다음과 같이 받아와서 인증된 회원의 정보를 조회할 수 있습니다.
+     * 현재는, principal.getName() 을 하면, 회원의 고유 식별 id (userId) 가 나오게 됩니다.
+     * @param principal
+     * @return
+     */
+    @GetMapping("/only-user")
+    @SecurityRequirement(name = "bearerAuth")
+    @Operation(summary = "회원만 접근 가능한 endPoint")
+    public BaseResponse<Void> getSampleDataOnlyUser(
+            Principal principal
+    ) {
+        System.out.println("userId : " + principal.getName());
+        return BaseResponse.ok(SuccessCode.SUCCESS);
+    }
+
+    /**
+     * admin 만 접근 가능한 endpoint 입니다.
+     * `SecurityConfig`에, `.requestMatchers` 로 설정된 부분이 영향을 줍니다.
+     * @param principal
+     * @return
+     */
+    @GetMapping("/only-admin")
+    @SecurityRequirement(name = "bearerAuth")
+    @Operation(summary = "회원만 접근 가능한 endPoint")
+    public BaseResponse<Void> getSampleDataOnlyAdmin(
+            Principal principal
+    ) {
+        System.out.println("admin userId : " + principal.getName());
+        return BaseResponse.ok(SuccessCode.SUCCESS);
     }
 }

--- a/backend/src/main/java/z9/second/global/annotation/validation/user/UserLoginId.java
+++ b/backend/src/main/java/z9/second/global/annotation/validation/user/UserLoginId.java
@@ -1,0 +1,19 @@
+package z9.second.global.annotation.validation.user;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Email;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Constraint(validatedBy = { })
+@Retention(RetentionPolicy.RUNTIME)
+@Email(message = "이메일 형식이 아닙니다.")
+public @interface UserLoginId {
+    String message() default "Invalid user email";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/z9/second/global/annotation/validation/user/UserPassword.java
+++ b/backend/src/main/java/z9/second/global/annotation/validation/user/UserPassword.java
@@ -1,0 +1,22 @@
+package z9.second.global.annotation.validation.user;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = { })
+@Size(min = 8, max = 20, message = "비밀번호는 8자리 ~ 20자리 사이 입니다.")
+@Pattern(regexp = "^(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).+$",
+        message = "비밀번호는 특수문자를 반드시 포함하여야 합니다.")
+public @interface UserPassword {
+    String message() default "Invalid user password";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/backend/src/main/java/z9/second/global/config/SecurityConfig.java
+++ b/backend/src/main/java/z9/second/global/config/SecurityConfig.java
@@ -1,0 +1,70 @@
+package z9.second.global.config;
+
+import static z9.second.global.security.constant.HeaderConstant.CONTENT_TYPE;
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
+
+import java.util.List;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    protected PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration)
+            throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    protected CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowCredentials(true);
+        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
+        configuration.setAllowedMethods(List.of("*"));
+        configuration.setAllowedHeaders(List.of(ACCESS_TOKEN_HEADER, CONTENT_TYPE));
+        configuration.setExposedHeaders(List.of(ACCESS_TOKEN_HEADER));
+        configuration.setMaxAge(3600L);
+
+        return request -> configuration;
+    }
+
+    @Bean
+    protected SecurityFilterChain filterChain(
+            HttpSecurity http, AuthenticationConfiguration authenticationConfiguration)
+            throws Exception {
+
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        http.sessionManagement((session) ->
+                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        http.cors((cors) ->
+                cors.configurationSource(corsConfigurationSource()));
+
+        http.authorizeHttpRequests((auth) -> auth
+                .anyRequest().permitAll());
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/z9/second/global/initdata/BaseInitData.java
+++ b/backend/src/main/java/z9/second/global/initdata/BaseInitData.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import z9.second.model.sample.SampleEntity;
 import z9.second.model.sample.SampleRepository;
+import z9.second.model.user.User;
+import z9.second.model.user.UserRepository;
 
 @Profile("dev")
 @Component
@@ -17,28 +20,54 @@ import z9.second.model.sample.SampleRepository;
 public class BaseInitData {
 
     private final SampleRepository sampleRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     void init() {
         List<SampleEntity> sampleData = createSampleData(10);
+        List<User> savedUserData = createUserData(10);
     }
 
     private List<SampleEntity> createSampleData(final int count) {
-        if(sampleRepository.count() != 0) {
+        if (sampleRepository.count() != 0) {
             return sampleRepository.findAll();
         }
-        if(count == 0) return null;
+        if (count == 0) {
+            return null;
+        }
 
         List<SampleEntity> savedDataList = new ArrayList<>();
-
-        for(int i=1; i<=count; i++) {
+        for (int i = 1; i <= count; i++) {
             String firstName = "김";
             String secondName = String.format("%s%d", "아무개", i);
-            SampleEntity sample = SampleEntity.builder().firstName(firstName).secondName(secondName).age(i).build();
+            SampleEntity sample = SampleEntity.builder().firstName(firstName).secondName(secondName)
+                    .age(i).build();
             savedDataList.add(sampleRepository.save(sample));
         }
 
         return savedDataList;
+    }
+
+    private List<User> createUserData(final int count) {
+        if (userRepository.count() != 0) {
+            return userRepository.findAll();
+        }
+        if (count == 0) {
+            return null;
+        }
+
+        List<User> savedUserList = new ArrayList<>();
+        for (int i = 1; i <= count; i++) {
+            String loginId = String.format("%s%d@email.com", "test", i);
+            String password = passwordEncoder.encode("!test1234");
+            String nickname = String.format("%s%d", "test", i);
+            savedUserList.add(
+                    userRepository.save(
+                            User.createNewUser(loginId, password, nickname)));
+        }
+
+        return savedUserList;
     }
 }

--- a/backend/src/main/java/z9/second/global/response/ErrorCode.java
+++ b/backend/src/main/java/z9/second/global/response/ErrorCode.java
@@ -15,6 +15,10 @@ public enum ErrorCode {
     //1000 ~ 1999
     // 오류 종류 : 인증/인가 에러 ex) token expired
     LOGIN_FAIL(HttpStatus.BAD_REQUEST, Boolean.FALSE, 1000, "잘못된 이메일 혹은 패스워드 입니다."),
+    INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, Boolean.FALSE, 1001, "유효하지 않은 Access Token 입니다."),
+    NEED_LOGIN(HttpStatus.UNAUTHORIZED, Boolean.FALSE, 1002, "로그인이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, Boolean.FALSE, 1003, "접근 권한이 부족합니다."),
+    ACCESS_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, Boolean.FALSE, 1004, "Access Token 이 만료되었습니다."),
 
     //2000 ~ 2999
     // 오류 종류 : 회원 도메인 에러

--- a/backend/src/main/java/z9/second/global/response/ErrorCode.java
+++ b/backend/src/main/java/z9/second/global/response/ErrorCode.java
@@ -14,7 +14,7 @@ public enum ErrorCode {
 
     //1000 ~ 1999
     // 오류 종류 : 인증/인가 에러 ex) token expired
-    // rkdtjd
+    LOGIN_FAIL(HttpStatus.BAD_REQUEST, Boolean.FALSE, 1000, "잘못된 이메일 혹은 패스워드 입니다."),
 
     //2000 ~ 2999
     // 오류 종류 : 회원 도메인 에러

--- a/backend/src/main/java/z9/second/global/response/SuccessCode.java
+++ b/backend/src/main/java/z9/second/global/response/SuccessCode.java
@@ -14,6 +14,7 @@ public enum SuccessCode {
     SAVE_SAMPLE_DATA_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "샘플 데이터 저장 성공!"),
 
     // Authentication / Authorization
+    LOGIN_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "로그인 성공"),
 
     // User
 

--- a/backend/src/main/java/z9/second/global/security/constant/HeaderConstant.java
+++ b/backend/src/main/java/z9/second/global/security/constant/HeaderConstant.java
@@ -1,0 +1,5 @@
+package z9.second.global.security.constant;
+
+public abstract class HeaderConstant {
+    public static final String CONTENT_TYPE = "Content-Type";
+}

--- a/backend/src/main/java/z9/second/global/security/constant/JWTConstant.java
+++ b/backend/src/main/java/z9/second/global/security/constant/JWTConstant.java
@@ -1,0 +1,14 @@
+package z9.second.global.security.constant;
+
+public abstract class JWTConstant {
+    public static final String ACCESS_TOKEN_HEADER = "Authorization";
+    public static final String REFRESH_TOKEN_HEADER = "RefreshToken";
+    public static final String ACCESS_TOKEN_PREFIX = "Bearer";
+
+    public static final String CLAIM_KEY_USER_ID = "userId";
+    public static final String CLAIM_KEY_USER_CATEGORY = "category";
+    public static final String CLAIM_KEY_USER_ROLE = "role";
+
+    public static final String ACCESS_TOKEN_CATEGORY = "accessToken";
+    public static final String REFRESH_TOKEN_CATEGORY = "refreshToken";
+}

--- a/backend/src/main/java/z9/second/global/security/entrypoint/CustomAccessDeniedEntryPoint.java
+++ b/backend/src/main/java/z9/second/global/security/entrypoint/CustomAccessDeniedEntryPoint.java
@@ -1,0 +1,31 @@
+package z9.second.global.security.entrypoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import z9.second.global.response.BaseResponse;
+import z9.second.global.response.ErrorCode;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedEntryPoint implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.FORBIDDEN);
+        response.setContentType("application/json");
+        response.setStatus(ErrorCode.FORBIDDEN.getHttpStatus().value());
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/backend/src/main/java/z9/second/global/security/entrypoint/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/z9/second/global/security/entrypoint/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package z9.second.global.security.entrypoint;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import z9.second.global.response.BaseResponse;
+import z9.second.global.response.ErrorCode;
+
+/**
+ * 인증 오류 handler
+ * token 으로 인증 없이, 인증이 필요한 endpoint 에 접근 시, 해당 entryPoint 로 공통 response 생성
+ */
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+
+        BaseResponse<Void> errorResponse = BaseResponse.fail(ErrorCode.NEED_LOGIN);
+        response.setContentType("application/json");
+        response.setStatus(ErrorCode.NEED_LOGIN.getHttpStatus().value());
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/backend/src/main/java/z9/second/global/security/filter/AuthenticationFilter.java
+++ b/backend/src/main/java/z9/second/global/security/filter/AuthenticationFilter.java
@@ -1,0 +1,102 @@
+package z9.second.global.security.filter;
+
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_CATEGORY;
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import z9.second.global.response.BaseResponse;
+import z9.second.global.response.ErrorCode;
+import z9.second.global.security.jwt.JWTUtil;
+import z9.second.global.security.user.CustomUserDetails;
+import z9.second.model.user.User;
+import z9.second.model.user.UserRole;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticationFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = extractAccessToken(request);
+
+        if (accessToken == null) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            validateAccessToken(accessToken);
+        } catch (JwtException e) {
+            handleJwtException(response, e);
+            return;
+        }
+
+        setAuthentication(accessToken);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractAccessToken(HttpServletRequest request) {
+        String accessToken = request.getHeader(ACCESS_TOKEN_HEADER);
+        if (accessToken != null && accessToken.startsWith(ACCESS_TOKEN_PREFIX)) {
+            return accessToken.substring(7);
+        }
+        return null;
+    }
+
+    private void validateAccessToken(String accessToken) throws JwtException {
+        jwtUtil.isExpired(accessToken);
+
+        String category = jwtUtil.getCategory(accessToken);
+        if (!ACCESS_TOKEN_CATEGORY.equals(category)) {
+            throw new JwtException("Invalid access token category");
+        }
+    }
+
+    private void handleJwtException(HttpServletResponse response, JwtException e) throws IOException {
+        if (e instanceof ExpiredJwtException) {
+            writeErrorResponse(response, ErrorCode.ACCESS_TOKEN_EXPIRED);
+        } else {
+            writeErrorResponse(response, ErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    private void setAuthentication(String accessToken) {
+        Long userId = Long.parseLong(jwtUtil.getUserId(accessToken));
+        String role = jwtUtil.getRole(accessToken);
+
+        User authUser = User.createSecurityContextUser(userId, UserRole.valueOf(role));
+        CustomUserDetails customUserDetails = new CustomUserDetails(authUser);
+        Authentication authToken = new UsernamePasswordAuthenticationToken(
+                customUserDetails, null, customUserDetails.getAuthorities());
+
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+    }
+
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+        BaseResponse<Void> errorResponse = BaseResponse.fail(errorCode);
+        response.setContentType("application/json");
+        response.setStatus(errorCode.getHttpStatus().value());
+        response.setCharacterEncoding("utf-8");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/backend/src/main/java/z9/second/global/security/filter/ReissueFilter.java
+++ b/backend/src/main/java/z9/second/global/security/filter/ReissueFilter.java
@@ -1,0 +1,29 @@
+package z9.second.global.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import z9.second.global.security.jwt.JWTUtil;
+
+/**
+ * AccessToken 이 expired 될 경우, RefreshToken 으로 재발급을 자동 진행해 줍니다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ReissueFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        //todo : jwt 재발급 절차 진행!
+        doFilter(request, response, filterChain);
+        return;
+    }
+}

--- a/backend/src/main/java/z9/second/global/security/jwt/JWTUtil.java
+++ b/backend/src/main/java/z9/second/global/security/jwt/JWTUtil.java
@@ -1,0 +1,55 @@
+package z9.second.global.security.jwt;
+
+import static z9.second.global.security.constant.JWTConstant.CLAIM_KEY_USER_CATEGORY;
+import static z9.second.global.security.constant.JWTConstant.CLAIM_KEY_USER_ID;
+import static z9.second.global.security.constant.JWTConstant.CLAIM_KEY_USER_ROLE;
+
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JWTUtil {
+
+    private final SecretKey secretKey;
+
+    public JWTUtil(@Value("${jwt.secret}") String secret) {
+        this.secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUserId(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+                .get(CLAIM_KEY_USER_ID, String.class);
+    }
+
+    public String getRole(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+                .get(CLAIM_KEY_USER_ROLE, String.class);
+    }
+
+    public String getCategory(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+                .get(CLAIM_KEY_USER_CATEGORY, String.class);
+    }
+
+    public Boolean isExpired(String token) {
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload()
+                .getExpiration().before(new Date());
+    }
+
+    public String createJwt(String category, String userId, String role, long expiredMs) {
+        return Jwts.builder()
+                .claim(CLAIM_KEY_USER_CATEGORY, category)
+                .claim(CLAIM_KEY_USER_ID, userId)
+                .claim(CLAIM_KEY_USER_ROLE, role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/backend/src/main/java/z9/second/global/security/jwt/JwtProperties.java
+++ b/backend/src/main/java/z9/second/global/security/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package z9.second.global.security.jwt;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class JwtProperties {
+
+    @Value("${jwt.token.access-expiration}")
+    private Long accessExpiration;
+
+    @Value("${jwt.token.refresh-expiration}")
+    private Long refreshExpiration;
+}

--- a/backend/src/main/java/z9/second/global/security/provider/CustomAuthenticationProvider.java
+++ b/backend/src/main/java/z9/second/global/security/provider/CustomAuthenticationProvider.java
@@ -1,0 +1,45 @@
+package z9.second.global.security.provider;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import z9.second.global.exception.CustomException;
+import z9.second.global.response.ErrorCode;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+            throws AuthenticationException {
+        String loginId = authentication.getName();
+        String password = authentication.getCredentials().toString();
+
+        UserDetails userDetails = userDetailsService.loadUserByUsername(loginId);
+
+        if(userDetails == null) {
+            throw new CustomException(ErrorCode.LOGIN_FAIL);
+        }
+
+        if(!passwordEncoder.matches(password, userDetails.getPassword())) {
+            throw new CustomException(ErrorCode.LOGIN_FAIL);
+        }
+
+        return new UsernamePasswordAuthenticationToken(userDetails, password, userDetails.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/backend/src/main/java/z9/second/global/security/user/CustomUserDetailService.java
+++ b/backend/src/main/java/z9/second/global/security/user/CustomUserDetailService.java
@@ -1,0 +1,27 @@
+package z9.second.global.security.user;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import z9.second.model.user.User;
+import z9.second.model.user.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User userData = userRepository.findByLoginId(username).orElse(null);
+
+        if (userData != null) {
+            return new CustomUserDetails(userData);
+        }
+
+        return null;
+    }
+}

--- a/backend/src/main/java/z9/second/global/security/user/CustomUserDetails.java
+++ b/backend/src/main/java/z9/second/global/security/user/CustomUserDetails.java
@@ -1,0 +1,31 @@
+package z9.second.global.security.user;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import z9.second.model.user.User;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+        collection.add((GrantedAuthority) () -> user.getRole().name());
+        return collection;
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getId().toString();
+    }
+}

--- a/backend/src/main/java/z9/second/model/user/User.java
+++ b/backend/src/main/java/z9/second/model/user/User.java
@@ -1,0 +1,61 @@
+package z9.second.model.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import z9.second.model.BaseEntity;
+
+@Entity
+@Getter
+@ToString
+@Table(name = "users")
+@Builder(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = false)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @Column(name = "user_id")
+    @GeneratedValue
+    private Long id;
+
+    @Column(name = "login_id", nullable = false, unique = true)
+    private String loginId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nickname", nullable = false, unique = true, length = 10)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private UserStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private UserRole role;
+
+    private static User createNewUser(String loginId, String password, String nickname) {
+        return User
+                .builder()
+                .loginId(loginId)
+                .password(password)
+                .nickname(nickname)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.ROLE_USER)
+                .build();
+    }
+}

--- a/backend/src/main/java/z9/second/model/user/User.java
+++ b/backend/src/main/java/z9/second/model/user/User.java
@@ -59,4 +59,12 @@ public class User extends BaseEntity {
                 .role(UserRole.ROLE_USER)
                 .build();
     }
+
+    public static User createSecurityContextUser(Long userId, UserRole userRole) {
+        return User
+                .builder()
+                .id(userId)
+                .role(userRole)
+                .build();
+    }
 }

--- a/backend/src/main/java/z9/second/model/user/User.java
+++ b/backend/src/main/java/z9/second/model/user/User.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -28,7 +29,7 @@ public class User extends BaseEntity {
 
     @Id
     @Column(name = "user_id")
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(name = "login_id", nullable = false, unique = true)
@@ -48,7 +49,7 @@ public class User extends BaseEntity {
     @Column(name = "role", nullable = false)
     private UserRole role;
 
-    private static User createNewUser(String loginId, String password, String nickname) {
+    public static User createNewUser(String loginId, String password, String nickname) {
         return User
                 .builder()
                 .loginId(loginId)

--- a/backend/src/main/java/z9/second/model/user/UserRepository.java
+++ b/backend/src/main/java/z9/second/model/user/UserRepository.java
@@ -1,0 +1,9 @@
+package z9.second.model.user;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByLoginId(String loginId);
+}

--- a/backend/src/main/java/z9/second/model/user/UserRole.java
+++ b/backend/src/main/java/z9/second/model/user/UserRole.java
@@ -1,0 +1,9 @@
+package z9.second.model.user;
+
+import lombok.Getter;
+
+@Getter
+public enum UserRole {
+    ROLE_USER,
+    ROLE_ADMIN,
+}

--- a/backend/src/main/java/z9/second/model/user/UserStatus.java
+++ b/backend/src/main/java/z9/second/model/user/UserStatus.java
@@ -1,0 +1,10 @@
+package z9.second.model.user;
+
+import lombok.Getter;
+
+@Getter
+public enum UserStatus {
+    ACTIVE,
+    RESIGN
+    ,
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,7 +5,6 @@ spring:
     additional-location: classpath:/config/
   profiles:
     group:
-      #      ?? ?? yml ? ?? setting ?? ????.
       #      prod: [ "prod_auth", "prod_db", "prod_web", "prod_server" ]
       dev: [ "dev_auth", "dev_db", "dev_web", "dev_server" ,"dev_docs" ]
     active: dev

--- a/backend/src/main/resources/config/application-dev_auth.yml
+++ b/backend/src/main/resources/config/application-dev_auth.yml
@@ -1,5 +1,5 @@
-#jwt:
-#  secret: ${JWT_SECRET}
-#  token:
-#    access-expiration: ${JWT_ACCESS_EXPIRATION}
-#    refresh-expiration: ${JWT_REFRESH_EXPIRATION}
+jwt:
+  secret: ${JWT_SECRET}
+  token:
+    access-expiration: ${JWT_ACCESS_EXPIRATION}
+    refresh-expiration: ${JWT_REFRESH_EXPIRATION}

--- a/backend/src/main/resources/config/application-dev_docs.yml
+++ b/backend/src/main/resources/config/application-dev_docs.yml
@@ -1,2 +1,3 @@
 springdoc:
   default-produces-media-type: application/json;charset=UTF-8
+  default-consumes-media-type: application/json;charset=UTF-8

--- a/backend/src/test/java/z9/second/domain/authentication/controller/AuthenticationControllerTest.java
+++ b/backend/src/test/java/z9/second/domain/authentication/controller/AuthenticationControllerTest.java
@@ -1,0 +1,54 @@
+package z9.second.domain.authentication.controller;
+
+
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
+import static z9.second.global.security.constant.JWTConstant.REFRESH_TOKEN_HEADER;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.authentication.dto.AuthenticationRequest;
+import z9.second.global.response.SuccessCode;
+import z9.second.integration.SpringBootTestSupporter;
+import z9.second.model.user.User;
+
+@Transactional
+class AuthenticationControllerTest extends SpringBootTestSupporter {
+
+    @DisplayName("로그인을 진행 합니다. access 는 헤더에, refresh 는 쿠키에 담겨서 response 됩니다")
+    @Test
+    void login() throws Exception {
+        // given
+        String loginId = "test@email.com";
+        String password = "!asdf1234";
+        String nickname = "테스터";
+        userRepository.save(User.createNewUser(loginId, passwordEncoder.encode(password), nickname));
+        AuthenticationRequest.Login request = AuthenticationRequest.Login.of(loginId, password);
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(SuccessCode.LOGIN_SUCCESS.getIsSuccess()))
+                .andExpect(jsonPath("$.message").value(SuccessCode.LOGIN_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.code").value(SuccessCode.LOGIN_SUCCESS.getCode()))
+                .andExpect(jsonPath("$.data").doesNotExist())
+                .andExpect(header().exists(ACCESS_TOKEN_HEADER))
+                .andExpect(header().string(ACCESS_TOKEN_HEADER, startsWith(ACCESS_TOKEN_PREFIX + " ")))
+                .andExpect(cookie().exists(REFRESH_TOKEN_HEADER));
+    }
+}

--- a/backend/src/test/java/z9/second/domain/authentication/dto/AuthenticationRequestTest.java
+++ b/backend/src/test/java/z9/second/domain/authentication/dto/AuthenticationRequestTest.java
@@ -1,0 +1,58 @@
+package z9.second.domain.authentication.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AuthenticationRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @DisplayName("로그인 Dto 유효성 검증")
+    @Test
+    void login1() {
+        // given
+        AuthenticationRequest.Login login =
+                AuthenticationRequest.Login.of("test@test.com", "!asdf1234");
+
+        // when
+        Set<ConstraintViolation<AuthenticationRequest.Login>> validate =
+                validator.validate(login);
+
+        // then
+        assertThat(validate).hasSize(0);
+    }
+
+    @DisplayName("잘못된 로그인 정보는 오류가 발생됩니다.")
+    @Test
+    void login2() {
+        // given
+        AuthenticationRequest.Login login =
+                AuthenticationRequest.Login.of("test", "1234");
+
+        // when
+        Set<ConstraintViolation<AuthenticationRequest.Login>> validate = validator.validate(login);
+
+        // then
+        assertThat(validate).hasSize(3);
+        assertThat(validate.stream()
+                .anyMatch(v -> v.getMessage().equals("이메일 형식이 아닙니다."))).isTrue();
+        assertThat(validate.stream()
+                .anyMatch(v -> v.getMessage().equals("비밀번호는 8자리 ~ 20자리 사이 입니다."))).isTrue();
+        assertThat(validate.stream()
+                .anyMatch(v -> v.getMessage().equals("비밀번호는 특수문자를 반드시 포함하여야 합니다."))).isTrue();
+    }
+}

--- a/backend/src/test/java/z9/second/domain/authentication/service/AuthenticationServiceImplTest.java
+++ b/backend/src/test/java/z9/second/domain/authentication/service/AuthenticationServiceImplTest.java
@@ -1,0 +1,57 @@
+package z9.second.domain.authentication.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.authentication.dto.AuthenticationRequest;
+import z9.second.domain.authentication.dto.AuthenticationResponse;
+import z9.second.global.exception.CustomException;
+import z9.second.global.response.ErrorCode;
+import z9.second.integration.SpringBootTestSupporter;
+import z9.second.model.user.User;
+
+@Transactional
+class AuthenticationServiceImplTest extends SpringBootTestSupporter {
+
+    @DisplayName("로그인 아이디로, 로그인을 진행 합니다. 성공되면, access/refresh token 을 반환합니다.")
+    @Test
+    void login() {
+        // given
+        String loginId = "test@email.com";
+        String password = "!test1234";
+        String nickName = "테스터";
+        userRepository.save(
+                User.createNewUser(loginId, passwordEncoder.encode(password), nickName));
+        em.flush();
+        em.clear();
+
+        // when
+        AuthenticationResponse.UserToken userToken = authenticationService.login(
+                AuthenticationRequest.Login.of(loginId, password));
+
+        // then
+        assertThat(userToken.getAccessToken())
+                .isNotNull()
+                .startsWith(ACCESS_TOKEN_PREFIX);
+        assertThat(userToken.getRefreshToken())
+                .isNotNull();
+    }
+
+    @DisplayName("로그인 아이디가 틀리거나, 등등 로그인이 불가능하다면 오류 메세지가 출력됩니다!")
+    @Test
+    void login2() {
+        // given
+        String loginId = "test@email.com";
+        String password = "!test1234";
+
+        // when // then
+        assertThatThrownBy(() -> authenticationService.login(AuthenticationRequest.Login.of(loginId, password)))
+                .isInstanceOf(CustomException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.LOGIN_FAIL);
+    }
+}

--- a/backend/src/test/java/z9/second/integration/SpringBootTestSupporter.java
+++ b/backend/src/test/java/z9/second/integration/SpringBootTestSupporter.java
@@ -1,0 +1,49 @@
+package z9.second.integration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import z9.second.domain.authentication.service.AuthenticationService;
+import z9.second.model.user.UserRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public abstract class SpringBootTestSupporter {
+
+    /**
+     * mock Mvc
+     */
+    @Autowired
+    public MockMvc mockMvc;
+
+    /**
+     * repository
+     */
+    @Autowired
+    protected UserRepository userRepository;
+
+
+    /**
+     * service
+     */
+    @Autowired
+    protected AuthenticationService authenticationService;
+
+    /**
+     * Common
+     */
+    @Autowired
+    protected EntityManager em;
+
+    @Autowired
+    protected PasswordEncoder passwordEncoder;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+}

--- a/backend/src/test/java/z9/second/model/user/UserRepositoryTest.java
+++ b/backend/src/test/java/z9/second/model/user/UserRepositoryTest.java
@@ -1,0 +1,35 @@
+package z9.second.model.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+import z9.second.integration.SpringBootTestSupporter;
+
+@Transactional
+class UserRepositoryTest extends SpringBootTestSupporter {
+
+    @DisplayName("로그인 아이디로, 사용자 정보를 조회합니다.")
+    @Test
+    void findByLoginId() {
+        // given
+        String loginId = "test@email.com";
+        String password = "!asdf1234";
+        String nickname ="테스터";
+        User savedUser = userRepository.save(User.createNewUser(loginId, password, nickname));
+        em.flush();
+        em.clear();
+
+        // when
+        Optional<User> findOptionalData = userRepository.findByLoginId(loginId);
+
+        // then
+        assertThat(findOptionalData).isPresent();
+        User findData = findOptionalData.get();
+        assertThat(findData)
+                .extracting("loginId", "nickname", "status", "role", "id")
+                .containsExactly(loginId, nickname, UserStatus.ACTIVE, UserRole.ROLE_USER, savedUser.getId());
+    }
+}

--- a/backend/src/test/resources/config/application-test_auth.yml
+++ b/backend/src/test/resources/config/application-test_auth.yml
@@ -1,23 +1,5 @@
-spring:
-  mail:
-    host: localhost
-    port: 3025
-    username: greenmail
-    password: greenmail
-    properties:
-      mail:
-        smtp:
-          starttls:
-            enable: false
-            required: false
-
-#JWT config
 jwt:
-  secret: c99197156d1d4db89296e58473b8d37c3bd2285ae5014594ac211603b44071feDFASDFASDFASDFASDFASDF
+  secret: 'testSecret_testSecret_testSecret_testSecret_testSecret_testSecret_testSecret_123123333'
   token:
-    access-expiration: 1800
-    refresh-expiration: 604800
-
-#Email config
-email:
-  from: no-reply@app.com
+    access-expiration: 3000
+    refresh-expiration: 3000000


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#6 
  <br/>

## 🔎 작업 내용
- 회원 로그인 기능을 구현하였습니다.
  -  현재 로그인 후, `Header`에 `Authorization : Bearer ${AccessToken}`, `Cookie`에 `RefreshToken : ${RefreshToken}` 이 담기도록 되어있습니다.
- 전체 통합 테스트 진행하였습니다.
- 인가 부분이 처리되었습니다.
  - controller 에서, `Principal`을 받아와, `getName()` 을 실행하면, 해당 토큰으로 인증된 유저의 고유 id 값 (table 상 user_id) 가 반환됩니다!
  - 해당 부분은, `SampleController` 의 `/only-user` endpoint 를 참조 하시기 바랍니다!

- ❗ 현재 기능이 머지되고, `git pull origin dev` 을 실행한다면, .env 파일에 몇가지 환경 변수가 추가되어야합니다!
  - 해당 부분은, readme.md 에 명시되어있습니다!
  - secretKey는 아무렇게나 지정하시면 됩니다! 길게만!

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
- security 쪽이라 작업 량이 좀 많이 되어있습니다 ㅠㅠ
  - 코드컨벤션에 안맞거나, 용도에 맞지 않는 네이밍등 리뷰 부탁드립니다~!
  - 혹은, 설명이 부족하여 이해가 안되는 부분이 있다면 같이 코멘트 부탁드립니다!!

  <br/>

## 📈이미지 첨부 (필요시)
- 로그인 성공 시, accessToken 반환되는 모습
![image](https://github.com/user-attachments/assets/469f9c5b-cf45-467b-9ade-c749132c4e0d)
- 로그인 성공 시, refreshToken 쿠키에 저장된 모습
![image](https://github.com/user-attachments/assets/388eca1d-2570-41a9-a22c-4914f5352d4c)
- Swagger 에서, 발급받은 accessToken 추가하는 방법
![image](https://github.com/user-attachments/assets/a80980f5-a76e-494f-bfc5-d41aac08720a)
- 토큰 없이, 로그인한 사용자만 접근 가능한 end-point 에 접근했을때
![image](https://github.com/user-attachments/assets/43c803f1-78fb-4892-83df-b08e99eb5941)



  <br/>