### PR TITLE
[FEAT] : 로그아웃 구현

### DIFF
--- a/backend/src/main/java/z9/second/domain/authentication/controller/AuthenticationController.java
+++ b/backend/src/main/java/z9/second/domain/authentication/controller/AuthenticationController.java
@@ -1,14 +1,16 @@
 package z9.second.domain.authentication.controller;
 
 import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
-import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
 import static z9.second.global.security.constant.JWTConstant.REFRESH_TOKEN_HEADER;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.security.Principal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -56,15 +58,34 @@ public class AuthenticationController {
         return BaseResponse.ok(SuccessCode.LOGIN_SUCCESS);
     }
 
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃")
+    @SecurityRequirement(name = "bearerAuth")
+    public BaseResponse<Void> logout(
+            HttpServletResponse response,
+            Principal principal) {
+        authenticationService.logout(principal.getName());
+        deleteRefreshTokenCookie(response);
+        return BaseResponse.ok(SuccessCode.LOGOUT_SUCCESS);
+    }
+
     private void addJwtTokenResponse(HttpServletResponse response, AuthenticationResponse.UserToken token) {
         ControllerUtils.addHeaderResponse(
                 ACCESS_TOKEN_HEADER,
-                String.format("%s %s", ACCESS_TOKEN_PREFIX, token.getAccessToken()),
+                ControllerUtils.makeBearerToken(token.getAccessToken()),
                 response);
         ControllerUtils.addCookieResponse(
                 REFRESH_TOKEN_HEADER,
                 token.getRefreshToken(),
                 ControllerUtils.parseMsToSec(jwtProperties.getRefreshExpiration()),
+                response);
+    }
+
+    private void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ControllerUtils.addCookieResponse(
+                REFRESH_TOKEN_HEADER,
+                null,
+                0,
                 response);
     }
 }

--- a/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationService.java
+++ b/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationService.java
@@ -8,4 +8,6 @@ public interface AuthenticationService {
     AuthenticationResponse.UserToken login(AuthenticationRequest.Login dto);
 
     AuthenticationResponse.UserToken oauthLogin(String provider, String authCode);
+
+    void logout(String userId);
 }

--- a/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationServiceImpl.java
+++ b/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationServiceImpl.java
@@ -1,7 +1,6 @@
 package z9.second.domain.authentication.service;
 
 import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_CATEGORY;
-import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
 import static z9.second.global.security.constant.JWTConstant.REFRESH_TOKEN_CATEGORY;
 
 import java.util.Map;

--- a/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationServiceImpl.java
+++ b/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationServiceImpl.java
@@ -27,6 +27,7 @@ import z9.second.global.security.oauth.OAuthToken;
 import z9.second.global.security.oauth.user.KakaoUserInfo;
 import z9.second.global.security.oauth.user.OAuth2UserInfo;
 import z9.second.global.security.user.CustomUserDetails;
+import z9.second.global.utils.ControllerUtils;
 import z9.second.model.oauthuser.OAuthUser;
 import z9.second.model.oauthuser.OAuthUserRepository;
 import z9.second.model.user.User;
@@ -76,6 +77,13 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                 user.getId().toString());
     }
 
+    @Transactional
+    @Override
+    public void logout(String userId) {
+        redisRepository.deleteRefreshToken(userId);
+        //todo : 추후, 여유 생기면 accessToken 또한 블랙리스트 추가하여 추가보안 설정.
+    }
+
     private User getUserByOAuth(OAuth2UserInfo oauth2UserInfo) {
         Optional<OAuthUser> findOptionalUser = oAuthUserRepository.findByProviderAndUid(
                 oauth2UserInfo.getProvider(), oauth2UserInfo.getProviderId());
@@ -83,7 +91,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         if (findOptionalUser.isEmpty()) {
             return createNewUserAndOAuthUser(oauth2UserInfo);
         }
-        return findUserByOAuthUser(findOptionalUser);
+        return findOptionalUser.get().getUser();
     }
 
     private OAuth2UserInfo getOauth2UserInfo(String provider, String authCode) {
@@ -99,7 +107,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
                         oAuthProperties.getContentType());
 
                 Map<String, Object> userInfoMap = kakaoResourceFeignClient.getUserInfo(
-                        String.format("%s %s", ACCESS_TOKEN_PREFIX, oAuthToken.getAccessToken()),
+                        ControllerUtils.makeBearerToken(oAuthToken.getAccessToken()),
                         oAuthProperties.getContentType());
 
                 oauth2UserInfo = new KakaoUserInfo(userInfoMap);
@@ -109,10 +117,6 @@ public class AuthenticationServiceImpl implements AuthenticationService {
             }
         }
         return oauth2UserInfo;
-    }
-
-    private static User findUserByOAuthUser(Optional<OAuthUser> findOptionalUser) {
-        return findOptionalUser.get().getUser();
     }
 
     private User createNewUserAndOAuthUser(OAuth2UserInfo oauth2UserInfo) {

--- a/backend/src/main/java/z9/second/global/config/SecurityConfig.java
+++ b/backend/src/main/java/z9/second/global/config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
     protected CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowCredentials(true);
-        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
+        configuration.setAllowedOrigins(List.of("http://localhost:3000"));
         configuration.setAllowedMethods(List.of("*"));
         configuration.setAllowedHeaders(List.of(ACCESS_TOKEN_HEADER, CONTENT_TYPE));
         configuration.setExposedHeaders(List.of(ACCESS_TOKEN_HEADER));

--- a/backend/src/main/java/z9/second/global/config/SecurityConfig.java
+++ b/backend/src/main/java/z9/second/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package z9.second.global.config;
 
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.POST;
 import static z9.second.global.security.constant.HeaderConstant.CONTENT_TYPE;
 import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
 
@@ -77,6 +78,7 @@ public class SecurityConfig {
         http.authorizeHttpRequests((auth) -> auth
                 .requestMatchers(GET, "/api/v1/sample/only-user").authenticated()
                 .requestMatchers(GET, "/api/v1/sample/only-admin").hasRole("ADMIN")
+                .requestMatchers(POST, "/api/v1/logout").authenticated()
                 .anyRequest().permitAll());
 
         http.exceptionHandling((exception) -> exception

--- a/backend/src/main/java/z9/second/global/response/SuccessCode.java
+++ b/backend/src/main/java/z9/second/global/response/SuccessCode.java
@@ -15,6 +15,7 @@ public enum SuccessCode {
 
     // Authentication / Authorization
     LOGIN_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "로그인 성공"),
+    LOGOUT_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "로그아웃 성공"),
 
     // User
 

--- a/backend/src/main/java/z9/second/global/security/filter/AuthenticationFilter.java
+++ b/backend/src/main/java/z9/second/global/security/filter/AuthenticationFilter.java
@@ -2,6 +2,7 @@ package z9.second.global.security.filter;
 
 import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_CATEGORY;
 import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.JwtException;
@@ -44,8 +45,8 @@ public class AuthenticationFilter extends OncePerRequestFilter {
         // 2-2. 만약 response 에 header 값이 있다면 token 이 재발급 된 것.
         // 해당 token 으로 인증 진행할 것
         String newAccessToken = response.getHeader(ACCESS_TOKEN_HEADER);
-        if (newAccessToken != null) {
-            accessToken = newAccessToken;
+        if (newAccessToken != null && newAccessToken.startsWith(ACCESS_TOKEN_PREFIX)) {
+            accessToken = newAccessToken.substring(7);
         }
 
         // 3. AccessToken 검증2

--- a/backend/src/main/java/z9/second/global/security/filter/ReissueFilter.java
+++ b/backend/src/main/java/z9/second/global/security/filter/ReissueFilter.java
@@ -80,17 +80,13 @@ public class ReissueFilter extends OncePerRequestFilter {
         // 7. 해당 api 요청 응답에 새로운 토큰 값 저장
         ControllerUtils.addHeaderResponse(
                 ACCESS_TOKEN_HEADER,
-                newAccessToken,
+                ControllerUtils.makeBearerToken(newAccessToken),
                 response);
         ControllerUtils.addCookieResponse(
                 REFRESH_TOKEN_HEADER,
                 newRefreshToken,
                 ControllerUtils.parseMsToSec(jwtProperties.getRefreshExpiration()),
                 response);
-
-        log.info(String.format("userId:%s 사용자, 토큰 재발급 되었습니다.", userId));
-        log.info(String.format("Refresh Token = %s", newRefreshToken));
-        log.info(String.format("Access Token = %s", newAccessToken));
 
         filterChain.doFilter(request, response);
     }

--- a/backend/src/main/java/z9/second/global/utils/ControllerUtils.java
+++ b/backend/src/main/java/z9/second/global/utils/ControllerUtils.java
@@ -1,5 +1,7 @@
 package z9.second.global.utils;
 
+import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
+
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 
@@ -25,5 +27,9 @@ public abstract class ControllerUtils {
 
     public static int parseMsToSec(Long ms) {
         return (int) (ms / 1000);
+    }
+
+    public static String makeBearerToken(String refreshToken) {
+        return String.format("%s %s", ACCESS_TOKEN_PREFIX, refreshToken);
     }
 }

--- a/backend/src/test/java/z9/second/integration/security/WithCustomUser.java
+++ b/backend/src/test/java/z9/second/integration/security/WithCustomUser.java
@@ -1,0 +1,15 @@
+package z9.second.integration.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomUserSecurityContextFactory.class)
+public @interface WithCustomUser {
+    String username() default "1";
+    String role() default "ROLE_USER";
+}

--- a/backend/src/test/java/z9/second/integration/security/WithCustomUserSecurityContextFactory.java
+++ b/backend/src/test/java/z9/second/integration/security/WithCustomUserSecurityContextFactory.java
@@ -1,0 +1,31 @@
+package z9.second.integration.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+import z9.second.global.security.user.CustomUserDetails;
+import z9.second.model.user.User;
+import z9.second.model.user.UserRole;
+
+public class WithCustomUserSecurityContextFactory implements
+        WithSecurityContextFactory<WithCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        User user = User.createSecurityContextUser(
+                Long.parseLong(annotation.username()),
+                UserRole.valueOf(annotation.role()));
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                customUserDetails, null, customUserDetails.getAuthorities());
+        context.setAuthentication(auth);
+
+        return context;
+
+    }
+}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#29 
  <br/>

## 🔎 작업 내용
- 회원 로그아웃 구현
  -  회원 로그아웃 시, 저장된 refreshToken 을 지움
  -  쿠키에 저장된 `key:RefreshToken` 삭제.
---
- 현재, 로그아웃 후, 유효기간이 남아있는 `AccessToken` 은 만료전 까지 사용 가능.
- 추후, `AccessToken` 에 black list 기능이 추가되면 로그아웃된 accessToken 은 다시 활용하지 못하게 추가 보안 업데이트 에정.
- 컨트롤러 단위 테스트 코드 작성.
  - 회원 모킹
  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>