### PR TITLE
[FEAT] : 회원 탈퇴 구현 (soft-delete 정책)

### DIFF
--- a/backend/src/main/java/z9/second/domain/authentication/controller/AuthenticationController.java
+++ b/backend/src/main/java/z9/second/domain/authentication/controller/AuthenticationController.java
@@ -1,7 +1,6 @@
 package z9.second.domain.authentication.controller;
 
 import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
-import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_PREFIX;
 import static z9.second.global.security.constant.JWTConstant.REFRESH_TOKEN_HEADER;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +11,7 @@ import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -76,6 +76,16 @@ public class AuthenticationController {
         authenticationService.logout(principal.getName());
         deleteRefreshTokenCookie(response);
         return BaseResponse.ok(SuccessCode.LOGOUT_SUCCESS);
+    }
+
+    @PatchMapping("/resign")
+    @Operation(summary = "회원 탈퇴")
+    @SecurityRequirement(name = "bearerAuth")
+    public BaseResponse<Void> resign(
+            Principal principal
+    ) {
+        authenticationService.resign(principal.getName());
+        return BaseResponse.ok(SuccessCode.RESIGN_SUCCESS);
     }
 
     private void addJwtTokenResponse(HttpServletResponse response, AuthenticationResponse.UserToken token) {

--- a/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationService.java
+++ b/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationService.java
@@ -12,4 +12,6 @@ public interface AuthenticationService {
     void signup(AuthenticationRequest.Signup signupDto);
 
     void logout(String userId);
+
+    void resign(String userId);
 }

--- a/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationServiceImpl.java
+++ b/backend/src/main/java/z9/second/domain/authentication/service/AuthenticationServiceImpl.java
@@ -82,6 +82,10 @@ public class AuthenticationServiceImpl implements AuthenticationService {
 
         User user = getUserByOAuth(oauth2UserInfo);
 
+        if(user.getStatus().equals(UserStatus.DELETE)) {
+            throw new CustomException(ErrorCode.LOGIN_RESIGN_USER);
+        }
+
         return generateUserTokens(
                 user.getRole().name(),
                 user.getId().toString());

--- a/backend/src/main/java/z9/second/domain/classes/repository/ClassRepository.java
+++ b/backend/src/main/java/z9/second/domain/classes/repository/ClassRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 
 public interface ClassRepository extends JpaRepository<ClassEntity, Long> {
     List<ClassEntity> findByMasterId(Long userId);
+
+    boolean existsByMasterId(Long userId);
 }

--- a/backend/src/main/java/z9/second/domain/classes/repository/ClassUserRepository.java
+++ b/backend/src/main/java/z9/second/domain/classes/repository/ClassUserRepository.java
@@ -9,4 +9,6 @@ public interface ClassUserRepository extends JpaRepository<ClassUserEntity, Long
     boolean existsByUserIdAndClassesId(Long userId, Long classId);
     boolean existsByClasses_IdAndUserId(Long classId, Long userId);
     Optional<ClassUserEntity> findByClassesIdAndUserId(Long classId, Long userId);
+
+    void deleteByUserId(Long userId);
 }

--- a/backend/src/main/java/z9/second/global/config/SecurityConfig.java
+++ b/backend/src/main/java/z9/second/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package z9.second.global.config;
 
 import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.PATCH;
 import static org.springframework.http.HttpMethod.POST;
 import static z9.second.global.security.constant.HeaderConstant.CONTENT_TYPE;
 import static z9.second.global.security.constant.JWTConstant.ACCESS_TOKEN_HEADER;
@@ -79,6 +80,7 @@ public class SecurityConfig {
                 .requestMatchers(GET, "/api/v1/sample/only-user").authenticated()
                 .requestMatchers(GET, "/api/v1/sample/only-admin").hasRole("ADMIN")
                 .requestMatchers(POST, "/api/v1/logout").authenticated()
+                .requestMatchers(PATCH, "/api/v1/resign").authenticated()
                 .anyRequest().permitAll());
 
         http.exceptionHandling((exception) -> exception

--- a/backend/src/main/java/z9/second/global/response/ErrorCode.java
+++ b/backend/src/main/java/z9/second/global/response/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
 
     //2000 ~ 2999
     // 오류 종류 : 회원 도메인 에러
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, Boolean.FALSE, 2000, "로그인 된 회원 정보 조회 실패. 재로그인 해주세요."),
+    ALREADY_DELETE_USER(HttpStatus.BAD_REQUEST, Boolean.FALSE, 2001, "이미 탈퇴된 회원입니다."),
 
     //3000 ~ 3999
     // 오류 종류 : 모임

--- a/backend/src/main/java/z9/second/global/response/ErrorCode.java
+++ b/backend/src/main/java/z9/second/global/response/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     // 오류 종류 : 회원 도메인 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, Boolean.FALSE, 2000, "로그인 된 회원 정보 조회 실패. 재로그인 해주세요."),
     ALREADY_DELETE_USER(HttpStatus.BAD_REQUEST, Boolean.FALSE, 2001, "이미 탈퇴된 회원입니다."),
+    LOGIN_RESIGN_USER(HttpStatus.BAD_REQUEST, Boolean.FALSE, 2002, "탈퇴된 회원 입니다."),
 
     //3000 ~ 3999
     // 오류 종류 : 모임

--- a/backend/src/main/java/z9/second/global/response/SuccessCode.java
+++ b/backend/src/main/java/z9/second/global/response/SuccessCode.java
@@ -17,6 +17,7 @@ public enum SuccessCode {
     LOGIN_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "로그인 성공"),
     LOGOUT_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "로그아웃 성공"),
     SIGNUP_SUCCESS(HttpStatus.CREATED, Boolean.TRUE, 201, "회원가입 성공"),
+    RESIGN_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "회원탈퇴 성공"),
 
     // User
 

--- a/backend/src/main/java/z9/second/global/security/provider/CustomAuthenticationProvider.java
+++ b/backend/src/main/java/z9/second/global/security/provider/CustomAuthenticationProvider.java
@@ -11,6 +11,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import z9.second.global.exception.CustomException;
 import z9.second.global.response.ErrorCode;
+import z9.second.global.security.user.CustomUserDetails;
+import z9.second.model.user.UserStatus;
 
 @Component
 @RequiredArgsConstructor
@@ -33,6 +35,11 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
 
         if(!passwordEncoder.matches(password, userDetails.getPassword())) {
             throw new CustomException(ErrorCode.LOGIN_FAIL);
+        }
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) userDetails;
+        if (customUserDetails.getUser().getStatus().equals(UserStatus.DELETE)) {
+            throw new CustomException(ErrorCode.LOGIN_RESIGN_USER);
         }
 
         return new UsernamePasswordAuthenticationToken(userDetails, password, userDetails.getAuthorities());

--- a/backend/src/main/java/z9/second/global/security/user/CustomUserDetails.java
+++ b/backend/src/main/java/z9/second/global/security/user/CustomUserDetails.java
@@ -2,12 +2,14 @@ package z9.second.global.security.user;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import z9.second.model.user.User;
 import z9.second.model.user.UserType;
 
+@Getter
 @RequiredArgsConstructor
 public class CustomUserDetails implements UserDetails {
 

--- a/backend/src/main/java/z9/second/model/user/User.java
+++ b/backend/src/main/java/z9/second/model/user/User.java
@@ -82,4 +82,17 @@ public class User extends BaseEntity {
                 .role(userRole)
                 .build();
     }
+
+    public static User resign(User user) {
+        return User
+                .builder()
+                .id(user.getId())
+                .loginId(user.getLoginId())
+                .password(user.getPassword())
+                .nickname(user.getNickname())
+                .type(user.getType())
+                .status(UserStatus.DELETE)
+                .role(user.getRole())
+                .build();
+    }
 }

--- a/backend/src/main/java/z9/second/model/userfavorite/UserFavoriteRepository.java
+++ b/backend/src/main/java/z9/second/model/userfavorite/UserFavoriteRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserFavoriteRepository extends JpaRepository<UserFavorite, Long> {
 
+    void deleteByUserId(Long userId);
 }


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#33 
  <br/>

## 🔎 작업 내용
- 회원 탈퇴 기능이 추가되었습니다.
  - soft-delete 정책으로 적용되었습니다.
  - 회원 데이터는 보존되며 추후 재 회원 가입시, 계정 데이터를 살릴 것인지 결정할 수 있습니다.
  - 몇가지 데이터는 즉시, 삭제됩니다.
    - 회원의 모임방 가입 정보. (모임 탈퇴 동일)
    - 회원의 관심사 목록
- 회원 탈퇴 시, 모임장 권한이 있는 경우, 탈퇴가 불가능 합니다. 모임삭제 or 모임 권한 위임을 해야 합니다.
- 탈퇴한 회원은 로그인이 불가능 합니다. (소셜, 일반 모두)

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>