### PR TITLE
[FIX]: TEST_MEETING_TIME 고정값으로 인한 테스트 실패 해결

### DIFF
--- a/backend/src/test/java/z9/second/domain/schedules/base/SchedulesBaseTest.java
+++ b/backend/src/test/java/z9/second/domain/schedules/base/SchedulesBaseTest.java
@@ -9,14 +9,22 @@ import z9.second.integration.SpringBootTestSupporter;
 import z9.second.model.schedules.SchedulesEntity;
 import z9.second.model.user.User;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 
 @Transactional
 public abstract class SchedulesBaseTest extends SpringBootTestSupporter {
     // 공통으로 사용되는 상수
     protected static final String TEST_PASSWORD = "!test1234";
-    protected static final String TEST_MEETING_TIME = "2025-02-05 14:00:00";
     protected static final String TEST_MEETING_TITLE = "테스트 일정";
+
+    // 고정된 시간 대신 현재 시간 기준 미래 시간 생성
+    protected String getTestMeetingTime() {
+        // 현재 시간으로부터 7일 후로 설정
+        LocalDateTime futureTime = LocalDateTime.now().plusDays(7);
+        return futureTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
 
     protected User createTestUser(String email, String nickname) {
         return userRepository.save(User.createNewUser(
@@ -35,11 +43,11 @@ public abstract class SchedulesBaseTest extends SpringBootTestSupporter {
                 .build());
     }
 
-    protected SchedulesEntity createTestSchedule(ClassEntity classEntity, String meetingTitle) {
+    protected SchedulesEntity createTestSchedule(ClassEntity classEntity) {
         return schedulesRepository.save(SchedulesEntity.builder()
                 .classes(classEntity)
-                .meetingTime("2025-02-05 14:00:00")
-                .meetingTitle(meetingTitle)
+                .meetingTime(getTestMeetingTime())
+                .meetingTitle(SchedulesBaseTest.TEST_MEETING_TITLE)
                 .build());
     }
 
@@ -57,7 +65,7 @@ public abstract class SchedulesBaseTest extends SpringBootTestSupporter {
     protected SchedulesRequestDto.RequestData createScheduleRequest(Long classId) {
         return SchedulesRequestDto.RequestData.builder()
                 .classId(classId)
-                .meetingTime(TEST_MEETING_TIME)
+                .meetingTime(getTestMeetingTime())
                 .meetingTitle(TEST_MEETING_TITLE)
                 .build();
     }

--- a/backend/src/test/java/z9/second/domain/schedules/controller/SchedulesControllerTest.java
+++ b/backend/src/test/java/z9/second/domain/schedules/controller/SchedulesControllerTest.java
@@ -42,7 +42,7 @@ class SchedulesControllerTest extends SchedulesBaseTest {
         classEntity = createTestClass(masterUser.getId());
 
         // 기본 스케줄과 요청 데이터 생성
-        scheduleEntity = createTestSchedule(classEntity, TEST_MEETING_TITLE);
+        scheduleEntity = createTestSchedule(classEntity);
         scheduleRequest = createScheduleRequest(classEntity.getId());
     }
 

--- a/backend/src/test/java/z9/second/domain/schedules/service/SchedulesServiceTest.java
+++ b/backend/src/test/java/z9/second/domain/schedules/service/SchedulesServiceTest.java
@@ -35,7 +35,7 @@ class SchedulesServiceTest extends SchedulesBaseTest {
         classEntity = createTestClass(masterUser.getId());
 
         // 테스트 스케줄 생성
-        scheduleEntity = createTestSchedule(classEntity, TEST_MEETING_TITLE);
+        scheduleEntity = createTestSchedule(classEntity);
 
         // 요청 데이터 생성
         scheduleRequest = createScheduleRequest(classEntity.getId());


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#44 
  <br/>

## 🔎 작업 내용
- 원인 : 고정된 시간으로 인해 미래 시간 체크하는 코드에서 에러 발생
- 수정: 테스트 코드에 meetingTime을 현재보다 7일 뒤로 설정

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>