### PR TITLE
[FEAT] : 회원 정보 조회 및 정보 수정 기능 구현

### DIFF
--- a/backend/src/main/java/z9/second/domain/user/controller/UserController.java
+++ b/backend/src/main/java/z9/second/domain/user/controller/UserController.java
@@ -1,0 +1,33 @@
+package z9.second.domain.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.security.Principal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import z9.second.domain.user.dto.UserResponse;
+import z9.second.domain.user.service.UserService;
+import z9.second.global.response.BaseResponse;
+import z9.second.global.response.SuccessCode;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+@Tag(name = "User Controller", description = "회원 관련 기능")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping
+    @Operation(summary = "회원 정보 조회")
+    @SecurityRequirement(name = "bearerAuth")
+    public BaseResponse<UserResponse.UserInfo> findUserInfo(
+            Principal principal) {
+        Long userId = Long.parseLong(principal.getName());
+        UserResponse.UserInfo findData = userService.findUserInfo(userId);
+        return BaseResponse.ok(SuccessCode.FIND_USER_INFO_SUCCESS, findData);
+    }
+}

--- a/backend/src/main/java/z9/second/domain/user/controller/UserController.java
+++ b/backend/src/main/java/z9/second/domain/user/controller/UserController.java
@@ -3,11 +3,15 @@ package z9.second.domain.user.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import z9.second.domain.user.dto.UserRequest;
 import z9.second.domain.user.dto.UserResponse;
 import z9.second.domain.user.service.UserService;
 import z9.second.global.response.BaseResponse;
@@ -29,5 +33,15 @@ public class UserController {
         Long userId = Long.parseLong(principal.getName());
         UserResponse.UserInfo findData = userService.findUserInfo(userId);
         return BaseResponse.ok(SuccessCode.FIND_USER_INFO_SUCCESS, findData);
+    }
+
+    @PatchMapping("/profile")
+    @Operation(summary = "회원 정보 수정")
+    @SecurityRequirement(name = "bearerAuth")
+    public BaseResponse<Void> modifyUserInfo(
+            @Valid @RequestBody UserRequest.PatchUserInfo requestDto,
+            Principal principal) {
+        userService.patchUserInfo(requestDto, Long.parseLong(principal.getName()));
+        return BaseResponse.ok(SuccessCode.PATCH_USER_INFO_SUCCESS);
     }
 }

--- a/backend/src/main/java/z9/second/domain/user/dto/UserRequest.java
+++ b/backend/src/main/java/z9/second/domain/user/dto/UserRequest.java
@@ -1,0 +1,5 @@
+package z9.second.domain.user.dto;
+
+public class UserRequest {
+
+}

--- a/backend/src/main/java/z9/second/domain/user/dto/UserRequest.java
+++ b/backend/src/main/java/z9/second/domain/user/dto/UserRequest.java
@@ -1,5 +1,33 @@
 package z9.second.domain.user.dto;
 
+import jakarta.validation.constraints.Size;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import z9.second.global.annotation.validation.user.UserNickname;
+
 public class UserRequest {
 
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class PatchUserInfo {
+        @UserNickname
+        private String nickname;
+
+        @Size(min = 1, message = "관심사는 하나 이상 등록되어야 합니다.")
+        private List<String> favorite;
+
+        public static PatchUserInfo of(String nickname, List<String> favorite) {
+            return PatchUserInfo
+                    .builder()
+                    .nickname(nickname)
+                    .favorite(favorite)
+                    .build();
+        }
+    }
 }

--- a/backend/src/main/java/z9/second/domain/user/dto/UserResponse.java
+++ b/backend/src/main/java/z9/second/domain/user/dto/UserResponse.java
@@ -1,0 +1,35 @@
+package z9.second.domain.user.dto;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import z9.second.model.user.User;
+
+public class UserResponse {
+
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class UserInfo {
+        private final String nickname;
+        private final String type;
+        private final String role;
+        private final String createdAt;
+        private final List<String> favorite;
+
+        public static UserInfo of(User user, List<String> favorite) {
+            String formattedDate = user.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            return UserInfo
+                    .builder()
+                    .nickname(user.getNickname())
+                    .type(user.getType().getValue())
+                    .role(user.getRole().getValue())
+                    .createdAt(formattedDate)
+                    .favorite(favorite)
+                    .build();
+        }
+    }
+}

--- a/backend/src/main/java/z9/second/domain/user/service/UserService.java
+++ b/backend/src/main/java/z9/second/domain/user/service/UserService.java
@@ -1,8 +1,11 @@
 package z9.second.domain.user.service;
 
+import z9.second.domain.user.dto.UserRequest;
 import z9.second.domain.user.dto.UserResponse;
 
 public interface UserService {
 
     UserResponse.UserInfo findUserInfo(Long userId);
+
+    void patchUserInfo(UserRequest.PatchUserInfo requestDto, Long userId);
 }

--- a/backend/src/main/java/z9/second/domain/user/service/UserService.java
+++ b/backend/src/main/java/z9/second/domain/user/service/UserService.java
@@ -1,0 +1,8 @@
+package z9.second.domain.user.service;
+
+import z9.second.domain.user.dto.UserResponse;
+
+public interface UserService {
+
+    UserResponse.UserInfo findUserInfo(Long userId);
+}

--- a/backend/src/main/java/z9/second/domain/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/z9/second/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,31 @@
+package z9.second.domain.user.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.user.dto.UserResponse;
+import z9.second.global.exception.CustomException;
+import z9.second.global.response.ErrorCode;
+import z9.second.model.user.User;
+import z9.second.model.user.UserRepository;
+import z9.second.model.userfavorite.UserFavoriteRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final UserFavoriteRepository userFavoriteRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public UserResponse.UserInfo findUserInfo(Long userId) {
+        User findUser = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        List<String> favorites = userFavoriteRepository.findFavoriteNamesByUserId(userId);
+
+        return UserResponse.UserInfo.of(findUser, favorites);
+    }
+}

--- a/backend/src/main/java/z9/second/global/config/SecurityConfig.java
+++ b/backend/src/main/java/z9/second/global/config/SecurityConfig.java
@@ -81,6 +81,9 @@ public class SecurityConfig {
                 .requestMatchers(GET, "/api/v1/sample/only-admin").hasRole("ADMIN")
                 .requestMatchers(POST, "/api/v1/logout").authenticated()
                 .requestMatchers(PATCH, "/api/v1/resign").authenticated()
+                //user Domain
+                .requestMatchers(GET, "/api/v1/users").authenticated()
+                .requestMatchers(PATCH, "/api/v1/users/profile").authenticated()
                 .anyRequest().permitAll());
 
         http.exceptionHandling((exception) -> exception

--- a/backend/src/main/java/z9/second/global/response/SuccessCode.java
+++ b/backend/src/main/java/z9/second/global/response/SuccessCode.java
@@ -20,6 +20,7 @@ public enum SuccessCode {
     RESIGN_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "회원탈퇴 성공"),
 
     // User
+    FIND_USER_INFO_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "회원정보 조회 성공"),
 
     // Class
     CLASS_CREATE_SUCCESS(HttpStatus.CREATED, Boolean.TRUE, 201, "모임이 생성되었습니다."),

--- a/backend/src/main/java/z9/second/global/response/SuccessCode.java
+++ b/backend/src/main/java/z9/second/global/response/SuccessCode.java
@@ -21,6 +21,7 @@ public enum SuccessCode {
 
     // User
     FIND_USER_INFO_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "회원정보 조회 성공"),
+    PATCH_USER_INFO_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "회원정보 수정 성공"),
 
     // Class
     CLASS_CREATE_SUCCESS(HttpStatus.CREATED, Boolean.TRUE, 201, "모임이 생성되었습니다."),

--- a/backend/src/main/java/z9/second/model/user/User.java
+++ b/backend/src/main/java/z9/second/model/user/User.java
@@ -95,4 +95,17 @@ public class User extends BaseEntity {
                 .role(user.getRole())
                 .build();
     }
+
+    public static User patchUserInfo(User user, String nickname) {
+        return User
+                .builder()
+                .id(user.getId())
+                .loginId(user.getLoginId())
+                .password(user.getPassword())
+                .nickname(nickname)
+                .type(user.getType())
+                .status(user.getStatus())
+                .role(user.getRole())
+                .build();
+    }
 }

--- a/backend/src/main/java/z9/second/model/user/UserRole.java
+++ b/backend/src/main/java/z9/second/model/user/UserRole.java
@@ -1,9 +1,14 @@
 package z9.second.model.user;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum UserRole {
-    ROLE_USER,
-    ROLE_ADMIN,
+    ROLE_USER("회원"),
+    ROLE_ADMIN("관리자"),
+
+    ;
+    private final String value;
 }

--- a/backend/src/main/java/z9/second/model/user/UserType.java
+++ b/backend/src/main/java/z9/second/model/user/UserType.java
@@ -1,7 +1,14 @@
 package z9.second.model.user;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum UserType {
-    NORMAL,
-    OAUTH
-    ,
+    NORMAL("일반 회원"),
+    OAUTH("소셜 회원"),
+    ;
+
+    private final String value;
 }

--- a/backend/src/main/java/z9/second/model/userfavorite/UserFavorite.java
+++ b/backend/src/main/java/z9/second/model/userfavorite/UserFavorite.java
@@ -2,6 +2,7 @@ package z9.second.model.userfavorite;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -37,7 +38,7 @@ public class UserFavorite {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "favorite_id")
     private FavoriteEntity favorite;
 

--- a/backend/src/main/java/z9/second/model/userfavorite/UserFavoriteRepository.java
+++ b/backend/src/main/java/z9/second/model/userfavorite/UserFavoriteRepository.java
@@ -1,8 +1,14 @@
 package z9.second.model.userfavorite;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserFavoriteRepository extends JpaRepository<UserFavorite, Long> {
 
     void deleteByUserId(Long userId);
+
+    @Query("SELECT f.name FROM UserFavorite uf JOIN uf.favorite f WHERE uf.user.id = :userId")
+    List<String> findFavoriteNamesByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/test/java/z9/second/domain/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/z9/second/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,66 @@
+package z9.second.domain.user.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.favorite.entity.FavoriteEntity;
+import z9.second.global.response.SuccessCode;
+import z9.second.integration.SpringBootTestSupporter;
+import z9.second.integration.security.WithCustomUser;
+import z9.second.model.user.User;
+import z9.second.model.user.UserRole;
+import z9.second.model.user.UserType;
+import z9.second.model.userfavorite.UserFavorite;
+
+@Transactional
+class UserControllerTest extends SpringBootTestSupporter {
+
+    @WithCustomUser
+    @DisplayName("로그인 정보로 회원 정보를 반환합니다.")
+    @Test
+    void findUserInfo() throws Exception {
+        // given
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        List<String> favorite = List.of("관심사1", "관심사2");
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+
+        userFavoriteRepository.save(
+                UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
+
+        em.flush();
+        em.clear();
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/users"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(SuccessCode.FIND_USER_INFO_SUCCESS.getIsSuccess()))
+                .andExpect(jsonPath("$.message").value(SuccessCode.FIND_USER_INFO_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.code").value(SuccessCode.FIND_USER_INFO_SUCCESS.getCode()))
+                .andExpect(jsonPath("$.data.nickname").value(nickname))
+                .andExpect(jsonPath("$.data.type").value(UserType.NORMAL.getValue()))
+                .andExpect(jsonPath("$.data.role").value(UserRole.ROLE_USER.getValue()))
+                .andExpect(jsonPath("$.data.createdAt").value(Matchers.matchesPattern("\\d{4}-\\d{2}-\\d{2}")))
+                .andExpect(jsonPath("$.data.favorite").isArray())
+                .andExpect(jsonPath("$.data.favorite.length()").value(2))
+                .andExpect(jsonPath("$.data.favorite").value(Matchers.containsInAnyOrder("관심사1", "관심사2")));
+    }
+}

--- a/backend/src/test/java/z9/second/domain/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/z9/second/domain/user/controller/UserControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -26,7 +27,10 @@ import z9.second.model.userfavorite.UserFavorite;
 @Transactional
 class UserControllerTest extends SpringBootTestSupporter {
 
-
+    @BeforeEach
+    void setUp() {
+        em.createNativeQuery("ALTER TABLE users ALTER COLUMN user_id RESTART WITH 1").executeUpdate();
+    }
 
     @WithCustomUser
     @DisplayName("로그인 정보로 회원 정보를 반환합니다.")
@@ -70,9 +74,6 @@ class UserControllerTest extends SpringBootTestSupporter {
     @DisplayName("회원의 정보를 수정 합니다. 관심사와 닉네임을 수정할 수 있습니다.")
     @Test
     void modifyUserInfo() throws Exception {
-        //test
-        List<User> all = userRepository.findAll();
-
         // given
         String loginId = "test1@email.com";
         String password = "!test1234";

--- a/backend/src/test/java/z9/second/domain/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/z9/second/domain/user/controller/UserControllerTest.java
@@ -1,6 +1,7 @@
 package z9.second.domain.user.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -9,9 +10,11 @@ import java.util.List;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 import z9.second.domain.favorite.entity.FavoriteEntity;
+import z9.second.domain.user.dto.UserRequest;
 import z9.second.global.response.SuccessCode;
 import z9.second.integration.SpringBootTestSupporter;
 import z9.second.integration.security.WithCustomUser;
@@ -22,6 +25,8 @@ import z9.second.model.userfavorite.UserFavorite;
 
 @Transactional
 class UserControllerTest extends SpringBootTestSupporter {
+
+
 
     @WithCustomUser
     @DisplayName("로그인 정보로 회원 정보를 반환합니다.")
@@ -43,9 +48,6 @@ class UserControllerTest extends SpringBootTestSupporter {
                 UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
         userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
 
-        em.flush();
-        em.clear();
-
         // when
         ResultActions result = mockMvc.perform(get("/api/v1/users"));
 
@@ -62,5 +64,43 @@ class UserControllerTest extends SpringBootTestSupporter {
                 .andExpect(jsonPath("$.data.favorite").isArray())
                 .andExpect(jsonPath("$.data.favorite.length()").value(2))
                 .andExpect(jsonPath("$.data.favorite").value(Matchers.containsInAnyOrder("관심사1", "관심사2")));
+    }
+
+    @WithCustomUser
+    @DisplayName("회원의 정보를 수정 합니다. 관심사와 닉네임을 수정할 수 있습니다.")
+    @Test
+    void modifyUserInfo() throws Exception {
+        //test
+        List<User> all = userRepository.findAll();
+
+        // given
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        List<String> favorite = List.of("관심사1", "관심사2");
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+
+        String changeNickname = "변경된닉네임";
+        UserRequest.PatchUserInfo request = UserRequest.PatchUserInfo.of(changeNickname, favorite);
+
+        // when
+        ResultActions result = mockMvc.perform(patch("/api/v1/users/profile")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(SuccessCode.PATCH_USER_INFO_SUCCESS.getIsSuccess()))
+                .andExpect(jsonPath("$.message").value(SuccessCode.PATCH_USER_INFO_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.code").value(SuccessCode.PATCH_USER_INFO_SUCCESS.getCode()))
+                .andExpect(jsonPath("$.data.nickname").doesNotExist());
     }
 }

--- a/backend/src/test/java/z9/second/domain/user/dto/UserRequestTest.java
+++ b/backend/src/test/java/z9/second/domain/user/dto/UserRequestTest.java
@@ -1,0 +1,54 @@
+package z9.second.domain.user.dto;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setupValidator() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @DisplayName("회원 정보 수정 dto 검증")
+    @Test
+    void PatchUserInfo() {
+        // given
+        UserRequest.PatchUserInfo requestDto = UserRequest.PatchUserInfo.of("test",
+                List.of("관심사1", "관심사2"));
+
+        // when
+        Set<ConstraintViolation<UserRequest.PatchUserInfo>> result = validator.validate(
+                requestDto);
+
+        // then
+        assertThat(result).hasSize(0);
+    }
+
+    @DisplayName("회원 정보 수정은, 올바른 닉네임과 하나 이상의 관심사가 등록되어야 합니다.")
+    @Test
+    void PatchUserInfo1() {
+        // given
+        UserRequest.PatchUserInfo requestDto = UserRequest.PatchUserInfo.of("!", List.of());
+
+        // when
+        Set<ConstraintViolation<UserRequest.PatchUserInfo>> result = validator.validate(
+                requestDto);
+
+        // then
+        assertThat(result).hasSize(2);
+    }
+}

--- a/backend/src/test/java/z9/second/domain/user/service/UserServiceImplTest.java
+++ b/backend/src/test/java/z9/second/domain/user/service/UserServiceImplTest.java
@@ -2,13 +2,17 @@ package z9.second.domain.user.service;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
 import z9.second.domain.favorite.entity.FavoriteEntity;
+import z9.second.domain.user.dto.UserRequest;
 import z9.second.domain.user.dto.UserResponse;
+import z9.second.global.exception.CustomException;
+import z9.second.global.response.ErrorCode;
 import z9.second.integration.SpringBootTestSupporter;
 import z9.second.model.user.User;
 import z9.second.model.user.UserRole;
@@ -76,5 +80,124 @@ class UserServiceImplTest extends SpringBootTestSupporter {
         assertThat(findData.getCreatedAt()).matches("\\d{4}-\\d{2}-\\d{2}");
         assertThat(findData.getFavorite())
                 .hasSize(0);
+    }
+
+    @DisplayName("회원 정보를 찾습니다. 없는 회원으로 조회 시, 오류 메세지가 서빙됩니다.")
+    @Test
+    void findUserInfo3() {
+        // given
+
+        em.flush();
+        em.clear();
+
+        // when // then
+        assertThatThrownBy(() -> userService.findUserInfo(1L))
+                .isInstanceOf(CustomException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @DisplayName("회원 정보를 수정 합니다.")
+    @Test
+    void patchUserInfo1() {
+        // given
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        List<String> favorite = List.of("관심사1", "관심사2");
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+
+        String changeNickname = "변경된닉네임";
+        UserRequest.PatchUserInfo request = UserRequest.PatchUserInfo.of(changeNickname, favorite);
+
+        em.flush();
+        em.clear();
+
+        // when
+        userService.patchUserInfo(request, saveUser.getId());
+
+        // then
+        User findUser = userRepository.findById(saveUser.getId()).get();
+        List<String> findFavoriteList = userFavoriteRepository.findFavoriteNamesByUserId(saveUser.getId());
+        assertThat(findUser)
+                .extracting("nickname")
+                .isEqualTo(changeNickname);
+        assertThat(findFavoriteList)
+                .hasSize(2)
+                .containsExactlyInAnyOrder("관심사1", "관심사2");
+    }
+
+    @DisplayName("회원 정보를 수정 합니다. 원래 있던 관심사가 입력되지 않으면 그전 데이터는 삭제 됩니다.")
+    @Test
+    void patchUserInfo2() {
+        // given
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        List<String> favorite = List.of("관심사1", "관심사2");
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
+
+        String changeNickname = "변경된닉네임";
+        UserRequest.PatchUserInfo request = UserRequest.PatchUserInfo.of(changeNickname, List.of(fe1.getName()));
+
+        em.flush();
+        em.clear();
+
+        // when
+        userService.patchUserInfo(request, saveUser.getId());
+
+        // then
+        User findUser = userRepository.findById(saveUser.getId()).get();
+        List<String> findFavoriteList = userFavoriteRepository.findFavoriteNamesByUserId(saveUser.getId());
+        assertThat(findUser)
+                .extracting("nickname")
+                .isEqualTo(changeNickname);
+        assertThat(findFavoriteList)
+                .hasSize(1)
+                .containsExactlyInAnyOrder("관심사1");
+    }
+
+    @DisplayName("회원 정보를 수정 합니다. 서버에 등록된 관심사가 아니라면, 오류가 발생합니다.")
+    @Test
+    void patchUserInfo3() {
+        // given
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        List<String> favorite = List.of("관심사1", "관심사2");
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1));
+
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+
+        String changeNickname = "변경된닉네임";
+        UserRequest.PatchUserInfo request = UserRequest.PatchUserInfo.of(changeNickname, favorite);
+
+        em.flush();
+        em.clear();
+
+        // when // then
+        assertThatThrownBy( () -> userService.patchUserInfo(request, saveUser.getId()))
+                .isInstanceOf(CustomException.class)
+                .extracting("code")
+                .isEqualTo(ErrorCode.NOT_EXIST_FAVORITE);
     }
 }

--- a/backend/src/test/java/z9/second/domain/user/service/UserServiceImplTest.java
+++ b/backend/src/test/java/z9/second/domain/user/service/UserServiceImplTest.java
@@ -1,0 +1,80 @@
+package z9.second.domain.user.service;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.favorite.entity.FavoriteEntity;
+import z9.second.domain.user.dto.UserResponse;
+import z9.second.integration.SpringBootTestSupporter;
+import z9.second.model.user.User;
+import z9.second.model.user.UserRole;
+import z9.second.model.user.UserType;
+import z9.second.model.userfavorite.UserFavorite;
+
+@Transactional
+class UserServiceImplTest extends SpringBootTestSupporter {
+
+    @DisplayName("회원 정보를 찾습니다.")
+    @Test
+    void findUserInfo() {
+        // given
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        List<String> favorite = List.of("관심사1", "관심사2");
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+
+        userFavoriteRepository.save(
+                UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
+
+        em.flush();
+        em.clear();
+
+        // when
+        UserResponse.UserInfo findData = userService.findUserInfo(saveUser.getId());
+
+        // then
+        assertThat(findData)
+                .extracting("nickname", "type", "role")
+                .containsExactly(nickname, UserType.NORMAL.getValue(), UserRole.ROLE_USER.getValue());
+        assertThat(findData.getCreatedAt()).matches("\\d{4}-\\d{2}-\\d{2}");
+        assertThat(findData.getFavorite())
+                .hasSize(2)
+                .containsExactlyInAnyOrder("관심사1", "관심사2");
+    }
+
+    @DisplayName("회원 정보를 찾습니다. 관심사가 없을 경우, 빈 배열이 출력되어야 합니다.")
+    @Test
+    void findUserInfo2() {
+        // given
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        em.flush();
+        em.clear();
+
+        // when
+        UserResponse.UserInfo findData = userService.findUserInfo(saveUser.getId());
+
+        // then
+        assertThat(findData)
+                .extracting("nickname", "type", "role")
+                .containsExactly(nickname, UserType.NORMAL.getValue(), UserRole.ROLE_USER.getValue());
+        assertThat(findData.getCreatedAt()).matches("\\d{4}-\\d{2}-\\d{2}");
+        assertThat(findData.getFavorite())
+                .hasSize(0);
+    }
+}

--- a/backend/src/test/java/z9/second/integration/SpringBootTestSupporter.java
+++ b/backend/src/test/java/z9/second/integration/SpringBootTestSupporter.java
@@ -10,6 +10,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import z9.second.domain.authentication.service.AuthenticationService;
+import z9.second.domain.user.service.UserService;
 import z9.second.global.redis.RedisRepository;
 import z9.second.domain.favorite.repository.FavoriteRepository;
 import z9.second.domain.classes.repository.ClassRepository;
@@ -17,6 +18,7 @@ import z9.second.domain.classes.repository.ClassUserRepository;
 import z9.second.domain.schedules.service.SchedulesService;
 import z9.second.model.schedules.SchedulesRepository;
 import z9.second.model.user.UserRepository;
+import z9.second.model.userfavorite.UserFavoriteRepository;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -36,6 +38,8 @@ public abstract class SpringBootTestSupporter {
     protected UserRepository userRepository;
     @Autowired
     protected FavoriteRepository favoriteRepository;
+    @Autowired
+    protected UserFavoriteRepository userFavoriteRepository;
 
 
     /**
@@ -43,6 +47,8 @@ public abstract class SpringBootTestSupporter {
      */
     @Autowired
     protected AuthenticationService authenticationService;
+    @Autowired
+    protected UserService userService;
 
     /**
      * Common

--- a/backend/src/test/java/z9/second/model/userfavorite/UserFavoriteRepositoryTest.java
+++ b/backend/src/test/java/z9/second/model/userfavorite/UserFavoriteRepositoryTest.java
@@ -1,0 +1,45 @@
+package z9.second.model.userfavorite;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.favorite.entity.FavoriteEntity;
+import z9.second.integration.SpringBootTestSupporter;
+import z9.second.model.user.User;
+
+@Transactional
+class UserFavoriteRepositoryTest extends SpringBootTestSupporter {
+
+    @DisplayName("회원 아이디로, 관심사 목록을 조회합니다.")
+    @Test
+    void findFavoriteNamesByUserId1() {
+        // given
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        List<String> favorite = List.of("관심사1", "관심사2");
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<String> findDataList = userFavoriteRepository.findFavoriteNamesByUserId(
+                saveUser.getId());
+
+        // then
+        assertThat(findDataList).hasSize(2);
+        assertThat(findDataList).containsExactlyInAnyOrder("관심사1", "관심사2");
+    }
+}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#42 
  <br/>

## 🔎 작업 내용
- 회원 정보 조회 API 구현되었습니다.
- 회원 정보 수정 API 구현되었습니다.
  -  회원 정보 수정 시, 관심사를 변경할 수 있는데, 관심사는 새로 입력받은 관심사로 전체 대체 됩니다.
  - 즉, 회원의 기존 관심사인, ["A", "B"] 가 있었고, ["C"] 라는 관심사 수정 요청을 받으면, 회원의 기존 `A`, `B` 관심사는 삭제 처리 됩니다.

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>