### PR TITLE
[FEAT] : 내 모임 일정 조회 기능 구현

### DIFF
--- a/backend/src/main/java/z9/second/domain/user/controller/UserController.java
+++ b/backend/src/main/java/z9/second/domain/user/controller/UserController.java
@@ -44,4 +44,15 @@ public class UserController {
         userService.patchUserInfo(requestDto, Long.parseLong(principal.getName()));
         return BaseResponse.ok(SuccessCode.PATCH_USER_INFO_SUCCESS);
     }
+
+    @GetMapping("/schedules")
+    @Operation(summary = "내 모임일정 전체 조회")
+    @SecurityRequirement(name = "bearerAuth")
+    public BaseResponse<UserResponse.UserSchedule> findUserSchedules(
+            Principal principal){
+        UserResponse.UserSchedule findData
+                = userService.findUserSchedules(Long.parseLong(principal.getName()));
+
+        return BaseResponse.ok(SuccessCode.FIND_USER_SCHEDULES_SUCCESS, findData);
+    }
 }

--- a/backend/src/main/java/z9/second/domain/user/controller/UserController.java
+++ b/backend/src/main/java/z9/second/domain/user/controller/UserController.java
@@ -50,6 +50,8 @@ public class UserController {
     @SecurityRequirement(name = "bearerAuth")
     public BaseResponse<UserResponse.UserSchedule> findUserSchedules(
             Principal principal){
+        //todo : 필터링 조건 추가. 참석 여부, 검색 기준일 (지나간 모임 일정은 따로 빼서 쓰는게 더 나을 수도)
+        //todo : sorting 조건 추가. 현재 모임 meeting 시간 기준 내림 차순 정렬.
         UserResponse.UserSchedule findData
                 = userService.findUserSchedules(Long.parseLong(principal.getName()));
 

--- a/backend/src/main/java/z9/second/domain/user/dto/UserResponse.java
+++ b/backend/src/main/java/z9/second/domain/user/dto/UserResponse.java
@@ -6,6 +6,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import z9.second.model.schedules.SchedulesEntity;
 import z9.second.model.user.User;
 
 public class UserResponse {
@@ -29,6 +30,34 @@ public class UserResponse {
                     .role(user.getRole().getValue())
                     .createdAt(formattedDate)
                     .favorite(favorite)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class UserSchedule {
+        private final List<ScheduleInfo> schedule;
+
+        public static UserSchedule of(List<ScheduleInfo> schedule) {
+            return UserSchedule.builder().schedule(schedule).build();
+        }
+    }
+
+    @Getter
+    @Builder(access = AccessLevel.PRIVATE)
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    public static class ScheduleInfo {
+        private final Long classId;
+        private final String meetingTime; //yyyy-MM-dd HH:mm:ss
+        private final String meetingTitle;
+
+        public static ScheduleInfo from(SchedulesEntity schedulesEntity) {
+            return ScheduleInfo.builder()
+                    .classId(schedulesEntity.getClasses().getId())
+                    .meetingTime(schedulesEntity.getMeetingTime())
+                    .meetingTitle(schedulesEntity.getMeetingTitle())
                     .build();
         }
     }

--- a/backend/src/main/java/z9/second/domain/user/service/UserService.java
+++ b/backend/src/main/java/z9/second/domain/user/service/UserService.java
@@ -8,4 +8,6 @@ public interface UserService {
     UserResponse.UserInfo findUserInfo(Long userId);
 
     void patchUserInfo(UserRequest.PatchUserInfo requestDto, Long userId);
+
+    UserResponse.UserSchedule findUserSchedules(Long userId);
 }

--- a/backend/src/main/java/z9/second/domain/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/z9/second/domain/user/service/UserServiceImpl.java
@@ -11,6 +11,8 @@ import z9.second.domain.user.dto.UserRequest;
 import z9.second.domain.user.dto.UserResponse;
 import z9.second.global.exception.CustomException;
 import z9.second.global.response.ErrorCode;
+import z9.second.model.schedules.SchedulesEntity;
+import z9.second.model.schedules.SchedulesRepository;
 import z9.second.model.user.User;
 import z9.second.model.user.UserRepository;
 import z9.second.model.userfavorite.UserFavorite;
@@ -23,6 +25,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final UserFavoriteRepository userFavoriteRepository;
     private final FavoriteRepository favoriteRepository;
+    private final SchedulesRepository schedulesRepository;
 
     @Transactional(readOnly = true)
     @Override
@@ -64,5 +67,17 @@ public class UserServiceImpl implements UserService {
             userFavoriteList.add(newUserFavorite);
         }
         userFavoriteRepository.saveAll(userFavoriteList);
+    }
+
+    @Transactional(readOnly = true)
+    @Override
+    public UserResponse.UserSchedule findUserSchedules(Long userId) {
+        List<SchedulesEntity> findData = schedulesRepository.findUserSchedulesInfoByUserId(userId);
+
+        List<UserResponse.ScheduleInfo> scheduleInfoList = findData.stream()
+                .map(UserResponse.ScheduleInfo::from)
+                .toList();
+
+        return UserResponse.UserSchedule.of(scheduleInfoList);
     }
 }

--- a/backend/src/main/java/z9/second/global/config/SecurityConfig.java
+++ b/backend/src/main/java/z9/second/global/config/SecurityConfig.java
@@ -84,6 +84,7 @@ public class SecurityConfig {
                 //user Domain
                 .requestMatchers(GET, "/api/v1/users").authenticated()
                 .requestMatchers(PATCH, "/api/v1/users/profile").authenticated()
+                .requestMatchers(GET, "/api/v1/users/schedules").authenticated()
                 .anyRequest().permitAll());
 
         http.exceptionHandling((exception) -> exception

--- a/backend/src/main/java/z9/second/global/response/SuccessCode.java
+++ b/backend/src/main/java/z9/second/global/response/SuccessCode.java
@@ -22,6 +22,7 @@ public enum SuccessCode {
     // User
     FIND_USER_INFO_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "회원정보 조회 성공"),
     PATCH_USER_INFO_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "회원정보 수정 성공"),
+    FIND_USER_SCHEDULES_SUCCESS(HttpStatus.OK, Boolean.TRUE, 200, "회원 모임 일정 조회 성공"),
 
     // Class
     CLASS_CREATE_SUCCESS(HttpStatus.CREATED, Boolean.TRUE, 201, "모임이 생성되었습니다."),

--- a/backend/src/main/java/z9/second/model/schedules/SchedulesCheckInEntityRepository.java
+++ b/backend/src/main/java/z9/second/model/schedules/SchedulesCheckInEntityRepository.java
@@ -1,0 +1,6 @@
+package z9.second.model.schedules;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SchedulesCheckInEntityRepository extends JpaRepository<SchedulesCheckInEntity, Long> {
+}

--- a/backend/src/main/java/z9/second/model/schedules/SchedulesRepository.java
+++ b/backend/src/main/java/z9/second/model/schedules/SchedulesRepository.java
@@ -16,6 +16,7 @@ public interface SchedulesRepository extends JpaRepository<SchedulesEntity, Long
 
     @Query("SELECT s FROM SchedulesEntity s " +
             "JOIN FETCH s.checkins sc " +
-            "WHERE sc.userId = :userId AND sc.checkIn = true")
+            "WHERE sc.userId = :userId AND sc.checkIn = true " +
+            "ORDER BY s.meetingTime DESC")
     List<SchedulesEntity> findUserSchedulesInfoByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/z9/second/model/schedules/SchedulesRepository.java
+++ b/backend/src/main/java/z9/second/model/schedules/SchedulesRepository.java
@@ -4,6 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SchedulesRepository extends JpaRepository<SchedulesEntity, Long> {
     // 클래스에 속한 모든 일정 조회
@@ -11,4 +13,9 @@ public interface SchedulesRepository extends JpaRepository<SchedulesEntity, Long
 
     // 특정 클래스의 특정 일정 조회
     Optional<SchedulesEntity> findScheduleByIdAndClassesId(Long scheduleId, Long classId);
+
+    @Query("SELECT s FROM SchedulesEntity s " +
+            "JOIN FETCH s.checkins sc " +
+            "WHERE sc.userId = :userId AND sc.checkIn = true")
+    List<SchedulesEntity> findUserSchedulesInfoByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/test/java/z9/second/domain/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/z9/second/domain/user/controller/UserControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,11 +16,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.classes.entity.ClassEntity;
 import z9.second.domain.favorite.entity.FavoriteEntity;
 import z9.second.domain.user.dto.UserRequest;
 import z9.second.global.response.SuccessCode;
 import z9.second.integration.SpringBootTestSupporter;
 import z9.second.integration.security.WithCustomUser;
+import z9.second.model.schedules.SchedulesCheckInEntity;
+import z9.second.model.schedules.SchedulesEntity;
 import z9.second.model.user.User;
 import z9.second.model.user.UserRole;
 import z9.second.model.user.UserType;
@@ -103,5 +108,87 @@ class UserControllerTest extends SpringBootTestSupporter {
                 .andExpect(jsonPath("$.message").value(SuccessCode.PATCH_USER_INFO_SUCCESS.getMessage()))
                 .andExpect(jsonPath("$.code").value(SuccessCode.PATCH_USER_INFO_SUCCESS.getCode()))
                 .andExpect(jsonPath("$.data.nickname").doesNotExist());
+    }
+
+    @WithCustomUser
+    @DisplayName("로그인 된 회원의 참석할 모임 정보를 모두 찾습니다.")
+    @Test
+    void findUserSchedules() throws Exception {
+        // given
+        //사용자 등록
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        //관심사 등록
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
+
+        //방 생성
+        ClassEntity newClass = ClassEntity.builder()
+                .name("새로운 모임")
+                .favorite(fe1.getName())
+                .description("모임 설명 글 입니다!!")
+                .masterId(saveUser.getId())
+                .build();
+        newClass.addMember(saveUser.getId());
+        ClassEntity saveClass = classRepository.save(newClass);
+
+        //스케줄 생성 2개
+        LocalDateTime now = LocalDateTime.now();
+        String formattedTime = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        SchedulesEntity schedules = SchedulesEntity.builder()
+                .classes(saveClass)
+                .meetingTime(formattedTime)
+                .meetingTitle("정기모임 1회차")
+                .build();
+        SchedulesEntity saveSchedule = schedulesRepository.save(schedules);
+
+        SchedulesEntity schedules2 = SchedulesEntity.builder()
+                .classes(saveClass)
+                .meetingTime(formattedTime)
+                .meetingTitle("정기모임 2회차")
+                .build();
+        SchedulesEntity saveSchedule2 = schedulesRepository.save(schedules2);
+
+        //체크인 등록 2개
+        SchedulesCheckInEntity newCheckin = SchedulesCheckInEntity
+                .builder()
+                .schedules(saveSchedule)
+                .userId(saveUser.getId())
+                .checkIn(true)
+                .build();
+        schedulesCheckInEntityRepository.save(newCheckin);
+
+        SchedulesCheckInEntity newCheckin2 = SchedulesCheckInEntity
+                .builder()
+                .schedules(saveSchedule)
+                .userId(saveUser.getId())
+                .checkIn(false)
+                .build();
+        schedulesCheckInEntityRepository.save(newCheckin2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        ResultActions result = mockMvc.perform(get("/api/v1/users/schedules"));
+
+        // then
+        result.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(SuccessCode.FIND_USER_SCHEDULES_SUCCESS.getIsSuccess()))
+                .andExpect(jsonPath("$.message").value(SuccessCode.FIND_USER_SCHEDULES_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.code").value(SuccessCode.FIND_USER_SCHEDULES_SUCCESS.getCode()))
+                .andExpect(jsonPath("$.data.schedule").isArray())
+                .andExpect(jsonPath("$.data.schedule.length()").value(1))
+                .andExpect(jsonPath("$.data.schedule[0].classId").isNotEmpty())
+                .andExpect(jsonPath("$.data.schedule[0].meetingTime").value(Matchers.matchesPattern("\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}")))
+                .andExpect(jsonPath("$.data.schedule[0].meetingTitle").value("정기모임 1회차"));
     }
 }

--- a/backend/src/test/java/z9/second/domain/user/service/UserServiceImplTest.java
+++ b/backend/src/test/java/z9/second/domain/user/service/UserServiceImplTest.java
@@ -4,16 +4,20 @@ package z9.second.domain.user.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.classes.entity.ClassEntity;
 import z9.second.domain.favorite.entity.FavoriteEntity;
 import z9.second.domain.user.dto.UserRequest;
 import z9.second.domain.user.dto.UserResponse;
 import z9.second.global.exception.CustomException;
 import z9.second.global.response.ErrorCode;
 import z9.second.integration.SpringBootTestSupporter;
+import z9.second.model.schedules.SchedulesCheckInEntity;
+import z9.second.model.schedules.SchedulesEntity;
 import z9.second.model.user.User;
 import z9.second.model.user.UserRole;
 import z9.second.model.user.UserType;
@@ -199,5 +203,79 @@ class UserServiceImplTest extends SpringBootTestSupporter {
                 .isInstanceOf(CustomException.class)
                 .extracting("code")
                 .isEqualTo(ErrorCode.NOT_EXIST_FAVORITE);
+    }
+
+    @DisplayName("회원이 참석 예정인 일정을 찾습니다.")
+    @Test
+    void findUserSchedules1() {
+        // given
+        //사용자 등록
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        //관심사 등록
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
+
+        //방 생성
+        ClassEntity newClass = ClassEntity.builder()
+                .name("새로운 모임")
+                .favorite(fe1.getName())
+                .description("모임 설명 글 입니다!!")
+                .masterId(saveUser.getId())
+                .build();
+        newClass.addMember(saveUser.getId());
+        ClassEntity saveClass = classRepository.save(newClass);
+
+        //스케줄 생성 2개
+        SchedulesEntity schedules = SchedulesEntity.builder()
+                .classes(saveClass)
+                .meetingTime(LocalDateTime.now().toString())
+                .meetingTitle("정기모임 1회차")
+                .build();
+        SchedulesEntity saveSchedule = schedulesRepository.save(schedules);
+
+        SchedulesEntity schedules2 = SchedulesEntity.builder()
+                .classes(saveClass)
+                .meetingTime(LocalDateTime.now().toString())
+                .meetingTitle("정기모임 2회차")
+                .build();
+        SchedulesEntity saveSchedule2 = schedulesRepository.save(schedules2);
+
+        //체크인 등록 2개
+        SchedulesCheckInEntity newCheckin = SchedulesCheckInEntity
+                .builder()
+                .schedules(saveSchedule)
+                .userId(saveUser.getId())
+                .checkIn(true)
+                .build();
+        schedulesCheckInEntityRepository.save(newCheckin);
+
+        SchedulesCheckInEntity newCheckin2 = SchedulesCheckInEntity
+                .builder()
+                .schedules(saveSchedule)
+                .userId(saveUser.getId())
+                .checkIn(false)
+                .build();
+        schedulesCheckInEntityRepository.save(newCheckin2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        UserResponse.UserSchedule findData = userService.findUserSchedules(saveUser.getId());
+
+        // then
+        assertThat(findData.getSchedule())
+                .hasSize(1);
+        assertThat(findData.getSchedule().getFirst())
+                .extracting("meetingTitle")
+                .isEqualTo("정기모임 1회차");
     }
 }

--- a/backend/src/test/java/z9/second/integration/SpringBootTestSupporter.java
+++ b/backend/src/test/java/z9/second/integration/SpringBootTestSupporter.java
@@ -16,6 +16,7 @@ import z9.second.domain.favorite.repository.FavoriteRepository;
 import z9.second.domain.classes.repository.ClassRepository;
 import z9.second.domain.classes.repository.ClassUserRepository;
 import z9.second.domain.schedules.service.SchedulesService;
+import z9.second.model.schedules.SchedulesCheckInEntityRepository;
 import z9.second.model.schedules.SchedulesRepository;
 import z9.second.model.user.UserRepository;
 import z9.second.model.userfavorite.UserFavoriteRepository;
@@ -40,6 +41,8 @@ public abstract class SpringBootTestSupporter {
     protected FavoriteRepository favoriteRepository;
     @Autowired
     protected UserFavoriteRepository userFavoriteRepository;
+    @Autowired
+    protected SchedulesCheckInEntityRepository schedulesCheckInEntityRepository;
 
 
     /**

--- a/backend/src/test/java/z9/second/model/schedules/SchedulesRepositoryTest.java
+++ b/backend/src/test/java/z9/second/model/schedules/SchedulesRepositoryTest.java
@@ -1,0 +1,134 @@
+package z9.second.model.schedules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+import z9.second.domain.classes.entity.ClassEntity;
+import z9.second.domain.favorite.entity.FavoriteEntity;
+import z9.second.integration.SpringBootTestSupporter;
+import z9.second.model.user.User;
+import z9.second.model.userfavorite.UserFavorite;
+
+@Transactional
+class SchedulesRepositoryTest extends SpringBootTestSupporter {
+
+    @DisplayName("회원 아이디로, 회원이 참석하기로 한 모임 일정을 찾습니다.")
+    @Test
+    void findUserSchedulesInfoByUserId1() {
+        // given
+        //사용자 등록
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        //관심사 등록
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
+
+        //방 생성
+        ClassEntity newClass = ClassEntity.builder()
+                .name("새로운 모임")
+                .favorite(fe1.getName())
+                .description("모임 설명 글 입니다!!")
+                .masterId(saveUser.getId())
+                .build();
+        newClass.addMember(saveUser.getId());
+        ClassEntity saveClass = classRepository.save(newClass);
+
+        //스케줄 생성
+        SchedulesEntity schedules = SchedulesEntity.builder()
+                .classes(saveClass)
+                .meetingTime(LocalDateTime.now().toString())
+                .meetingTitle("정기모임 1회차")
+                .build();
+        SchedulesEntity saveSchedule = schedulesRepository.save(schedules);
+
+        SchedulesEntity schedules2 = SchedulesEntity.builder()
+                .classes(saveClass)
+                .meetingTime(LocalDateTime.now().toString())
+                .meetingTitle("정기모임 2회차")
+                .build();
+        SchedulesEntity saveSchedule2 = schedulesRepository.save(schedules2);
+
+        //체크인 등록
+        SchedulesCheckInEntity newCheckin = SchedulesCheckInEntity
+                .builder()
+                .schedules(saveSchedule)
+                .userId(saveUser.getId())
+                .checkIn(true)
+                .build();
+        schedulesCheckInEntityRepository.save(newCheckin);
+
+        SchedulesCheckInEntity newCheckin2 = SchedulesCheckInEntity
+                .builder()
+                .schedules(saveSchedule)
+                .userId(saveUser.getId())
+                .checkIn(false)
+                .build();
+        schedulesCheckInEntityRepository.save(newCheckin2);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<SchedulesEntity> findData = schedulesRepository.findUserSchedulesInfoByUserId(
+                saveUser.getId());
+
+        // then
+        assertThat(findData)
+                .hasSize(1);
+
+        assertThat(findData.getFirst())
+                .extracting("meetingTitle")
+                .isEqualTo("정기모임 1회차");
+    }
+
+    @DisplayName("회원 아이디로, 회원이 참석하기로 한 모임 일정을 찾습니다. 없으면 빈 배열이 반환됩니다.")
+    @Test
+    void findUserSchedulesInfoByUserId2() {
+        // given
+        //사용자 등록
+        String loginId = "test1@email.com";
+        String password = "!test1234";
+        String nickname = "test";
+        User newUser = User.createNewUser(loginId, password, nickname);
+        User saveUser = userRepository.save(newUser);
+
+        //관심사 등록
+        FavoriteEntity fe1 = FavoriteEntity.createNewFavorite("관심사1");
+        FavoriteEntity fe2 = FavoriteEntity.createNewFavorite("관심사2");
+        List<FavoriteEntity> saveFavoriteEntities = favoriteRepository.saveAll(List.of(fe1, fe2));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(0)));
+        userFavoriteRepository.save(UserFavorite.createNewUserFavorite(saveUser, saveFavoriteEntities.get(1)));
+
+        //방 생성
+        ClassEntity newClass = ClassEntity.builder()
+                .name("새로운 모임")
+                .favorite(fe1.getName())
+                .description("모임 설명 글 입니다!!")
+                .masterId(saveUser.getId())
+                .build();
+        newClass.addMember(saveUser.getId());
+        ClassEntity saveClass = classRepository.save(newClass);
+
+        em.flush();
+        em.clear();
+
+        // when
+        List<SchedulesEntity> findData = schedulesRepository.findUserSchedulesInfoByUserId(
+                saveUser.getId());
+
+        // then
+        assertThat(findData)
+                .hasSize(0);
+    }
+}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
#54 
  <br/>

## 🔎 작업 내용
- 내 모임 일정을 모두 조회합니다.
---
- 현재, 내가 참석 한다고 체크 한 모임 일정만 조회되게 되어있습니다.
  - 추후, 내가 params로 조건을 만들어 필터링 추가 예정 입니다.
  - 검색 기준일, 참석 여부 선택 하도록 등등
 - sorting 조건이 meeting 시간 기준 내림차순으로 고정되어있습니다.
   - 추가적으로, 정렬 조건 변동 가능하게 기능 수정 예정 입니다.

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>